### PR TITLE
patch20230131: fix file operation return 401 error

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -204,7 +204,6 @@ def file_put(**kwargs):
             target_folder,
             project_code,
             zone,
-            user.access_token,
             resumable_id,
             zipping,
         )
@@ -376,7 +375,7 @@ def file_download(**kwargs):
         for path in paths:
             project_code = path.strip('/').split('/')[0]
             target_path = '/'.join(path.split('/')[1::])
-            item = search_item(project_code, zone, target_path, '', user.access_token)
+            item = search_item(project_code, zone, target_path, '')
             if item.get('code') == 200 and item.get('result'):
                 item_status = 'success'
                 item_result = item.get('result')

--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -23,7 +23,7 @@ class AppConfig(object):
         user_config_path = ConfigClass.config_path
         msg_path = ConfigClass.custom_path
         user_config_file = f'{user_config_path}/config.ini'
-        token_warn_need_refresh = 120  # seconds
+        token_warn_need_refresh = 280  # seconds
 
         # NOTE: there is a limitation on minio that
         # the multipart number is 10000. so we set

--- a/app/services/file_manager/file_list.py
+++ b/app/services/file_manager/file_list.py
@@ -37,7 +37,7 @@ class SrvFileList(metaclass=MetaService):
             source_type = 'project'
         else:
             source_type = 'project'
-            res = search_item(project_code, zone, folder_rel_path, 'folder', self.user.access_token)
+            res = search_item(project_code, zone, folder_rel_path, 'folder')
         get_url = AppConfig.Connections.url_bff + f'/v1/{project_code}/files/query'
         headers = {
             'Authorization': 'Bearer ' + self.user.access_token,

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -45,11 +45,11 @@ def compress_folder_to_zip(path):
     zipf.close()
 
 
-def assemble_path(f, target_folder, project_code, zone, access_token, resumable_id, zipping=False):
+def assemble_path(f, target_folder, project_code, zone, resumable_id, zipping=False):
     current_folder_node = target_folder + '/' + f.rstrip('/').split('/')[-1]
     result_file = current_folder_node
     name_folder = current_folder_node.split('/')[0].lower()
-    name_folder_res = search_item(project_code, zone, name_folder, 'name_folder', access_token)
+    name_folder_res = search_item(project_code, zone, name_folder, 'name_folder')
     name_folder_code = name_folder_res['code']
     name_folder_result = name_folder_res['result']
     if name_folder_code == 403:
@@ -58,7 +58,7 @@ def assemble_path(f, target_folder, project_code, zone, access_token, resumable_
         SrvErrorHandler.customized_handle(ECustomizedError.INVALID_NAMEFOLDER, True)
     if len(current_folder_node.split('/')) > 2:
         parent_path = name_folder + '/' + '/'.join(current_folder_node.split('/')[1:-1])
-        res = search_item(project_code, zone, parent_path, 'folder', access_token)
+        res = search_item(project_code, zone, parent_path, 'folder')
         if not res['result'] and not resumable_id:
             click.confirm(customized_error_msg(ECustomizedError.CREATE_FOLDER_IF_NOT_EXIST), abort=True)
         elif resumable_id:

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -396,7 +396,7 @@ class UploadClient:
 
         if source_file and self.zone == AppConfig.Env.core_zone:
             child_rel_path = new_file_object.object_path
-            child_item = search_item(self.project_code, self.zone, child_rel_path, 'file', self.user.access_token)
+            child_item = search_item(self.project_code, self.zone, child_rel_path, 'file')
             child_file = child_item['result']
             parent_file_geid = source_file['id']
             child_file_geid = child_file['id']

--- a/app/services/file_manager/file_upload/upload_validator.py
+++ b/app/services/file_manager/file_upload/upload_validator.py
@@ -45,9 +45,7 @@ class UploadEventValidator:
                     ECustomizedError.INVALID_UPLOAD_REQUEST, True, value='process pipeline name required'
                 )
             else:
-                source_file_info = search_item(
-                    self.project_code, AppConfig.Env.green_zone.lower(), self.source, 'file', self.token
-                )
+                source_file_info = search_item(self.project_code, AppConfig.Env.green_zone.lower(), self.source, 'file')
                 source_file_info = source_file_info['result']
                 if not source_file_info:
                     SrvErrorHandler.customized_handle(ECustomizedError.INVALID_SOURCE_FILE, True, value=self.source)

--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -22,6 +22,7 @@ import httpx
 import requests
 
 from app.configs.app_config import AppConfig
+from app.configs.user_config import UserConfig
 from app.services.output_manager.error_handler import ECustomizedError, SrvErrorHandler
 from app.services.user_authentication.decorator import require_valid_token
 from env import ConfigClass
@@ -39,7 +40,8 @@ def resilient_session():
 
 
 @require_valid_token()
-def search_item(project_code, zone, folder_relative_path, item_type, token, container_type='project'):
+def search_item(project_code, zone, folder_relative_path, item_type, container_type='project'):
+    token = UserConfig().access_token
     url = AppConfig.Connections.url_bff + '/v1/project/{}/search'.format(project_code)
     params = {
         'zone': zone,

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -19,40 +19,30 @@ test_project_code = 'testproject'
 
 
 def test_search_file_should_return_200(requests_mock, mocker):
-    mocker.patch(
-        'app.services.user_authentication.token_manager.SrvTokenManager.check_valid',
-        return_value=0
-    )
+    mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
     requests_mock.get(
-        f"http://bff_cli/v1/project/{test_project_code}/search",
+        f'http://bff_cli/v1/project/{test_project_code}/search',
         json={
-            "code": 200,
-            "error_msg": "",
-            "result": {
-                "id": "file-id",
-                "parent": 'parent-id',
-                "parent_path": 'folder1',
-                "restore_path": None,
-                "archived": False,
-                "type": "file",
-                "zone": 0,
-                "name": "test-file",
-                "size": 1048576,
-                "owner": "admin",
-                "container_code": test_project_code,
-                "container_type": "project",
-                "created_time": "2021-07-02 16:34:09.164000",
-                "last_updated_time": "2021-07-02 16:34:09.164000",
-                "storage": {
-                    'id': 'storage-id',
-                    'location_uri': 'minio-path',
-                    'version': 'version-id'
-                },
-                "extended": {
-                    "id": "extended-id",
-                    "extra": {"tags": [], "system_tags": [], "attributes": {}}
-                }
-            }
+            'code': 200,
+            'error_msg': '',
+            'result': {
+                'id': 'file-id',
+                'parent': 'parent-id',
+                'parent_path': 'folder1',
+                'restore_path': None,
+                'archived': False,
+                'type': 'file',
+                'zone': 0,
+                'name': 'test-file',
+                'size': 1048576,
+                'owner': 'admin',
+                'container_code': test_project_code,
+                'container_type': 'project',
+                'created_time': '2021-07-02 16:34:09.164000',
+                'last_updated_time': '2021-07-02 16:34:09.164000',
+                'storage': {'id': 'storage-id', 'location_uri': 'minio-path', 'version': 'version-id'},
+                'extended': {'id': 'extended-id', 'extra': {'tags': [], 'system_tags': [], 'attributes': {}}},
+            },
         },
         status_code=200,
     )
@@ -71,15 +61,8 @@ def test_search_file_should_return_200(requests_mock, mocker):
         'container_type': 'project',
         'created_time': '2021-07-02 16:34:09.164000',
         'last_updated_time': '2021-07-02 16:34:09.164000',
-        'storage': {
-            'id': 'storage-id',
-            'location_uri': 'minio-path',
-            'version': 'version-id'
-        },
-        'extended': {
-            'id': 'extended-id',
-            'extra': {'tags': [], 'system_tags': [], 'attributes': {}}
-        }
+        'storage': {'id': 'storage-id', 'location_uri': 'minio-path', 'version': 'version-id'},
+        'extended': {'id': 'extended-id', 'extra': {'tags': [], 'system_tags': [], 'attributes': {}}},
     }
-    res = search_item(test_project_code, 'zone', 'folder_relative_path', 'file', 'token', 'project')
+    res = search_item(test_project_code, 'zone', 'folder_relative_path', 'file', 'project')
     assert res['result'] == expected_result


### PR DESCRIPTION
## Summary

fixup the `search_item` passes the stale token to server, causing the 401 error

## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
