### PR TITLE
IHDC-193: Renew user token using keycloack:

### DIFF
--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -44,7 +44,6 @@ class AppConfig(object):
         greenroom_bucket_prefix = 'gr'
 
         keycloak_device_client_id = ConfigClass.keycloak_device_client_id
-        keycloack_client_secret = ConfigClass.keycloack_client_secret
 
     class Connections(object):
         section = 'connections'

--- a/app/services/user_authentication/token_manager.py
+++ b/app/services/user_authentication/token_manager.py
@@ -78,20 +78,15 @@ class SrvTokenManager(metaclass=MetaService):
 
     def refresh(self, azp: str):
         url = AppConfig.Connections.url_keycloak_token
-
-        if azp == 'harbor':
-            client_secret = AppConfig.Env.harbor_client_secret
-        elif azp == AppConfig.Env.keycloak_device_client_id:
-            client_secret = AppConfig.Env.keycloack_client_secret
-        else:
-            raise ValueError('invalid client_id')
-
         payload = {
             'grant_type': 'refresh_token',
             'refresh_token': self.config.refresh_token,
             'client_id': azp,
-            'client_secret': client_secret,
         }
+
+        if azp == 'harbor':
+            payload.update({'client_id': AppConfig.Env.harbor_client_secret})
+
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         response = requests.post(url, data=payload, headers=headers, verify=False)
         if response.status_code == 200:

--- a/env.py
+++ b/env.py
@@ -36,7 +36,6 @@ class Settings(BaseSettings):
     url_keycloak: str = ''
 
     keycloak_device_client_id: str = 'cli_test2'
-    keycloack_client_secret: str = ''
 
     VM_INFO: str = ''
 


### PR DESCRIPTION
## Summary

- remove SrvTokenManager.request_default_tokens and SrvTokenManager.request_harbor_tokens
- add SrvTokenManager.refresh that supports harbor and pilot client id
- replace 'kong' from the default value of require_valid_token with keycloak_device_client_id


## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

after run
```
poetry run pilotcli file list p01131/admin
poetry run pilotcli dataset list
poetry run pilotcli project list 
```
You should not get the error:
```
"Invalid refresh token. Token client and authorized client don't"
```