### PR TITLE
PILOT-2548: update the cli with new annotation permission

### DIFF
--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -155,6 +155,7 @@ def simple_upload(  # noqa: C901
         current_folder_node=target_folder,
         parent_folder_id=parent_folder_id,
         regular_file=regular_file,
+        tags=tags,
     )
 
     # here add the batch of 500 per loop, the pre upload api cannot

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -55,6 +55,7 @@ class UploadClient:
         process_pipeline: str = None,
         current_folder_node: str = '',
         regular_file: str = True,
+        tags: list = None,
     ):
         self.user = UserConfig()
         self.operator = self.user.username
@@ -79,6 +80,7 @@ class UploadClient:
         self.current_folder_node = current_folder_node
         self.parent_folder_id = parent_folder_id
         self.regular_file = regular_file
+        self.tags = tags
 
     def generate_meta(self, local_path: str) -> Tuple[int, int]:
         """
@@ -181,6 +183,7 @@ class UploadClient:
         )
 
         payload.update({'parent_folder_id': self.parent_folder_id})
+        payload.update({'folder_tags': self.tags})
         response = resilient_session().post(url, json=payload, headers=headers, timeout=None)
         if response.status_code == 200:
             result = response.json().get('result')


### PR DESCRIPTION
## Summary

There is new rbac rule to verify if user has permission to add the tags. user can add tags with upload files, thus adding a new logic to check `annotation` permission if `folder_tags` is shown. So cli will send the tags to preupload as well

## JIRA Issues

PILOT-2548

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [] Yes
- [x] No

## Test Directions

new test for tagging permission
