### PR TITLE
PILOT-2379: fixup the token fresh will immediately exit after the async function

### DIFF
--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -12,7 +12,7 @@ class AppConfig(object):
         user_config_path = ConfigClass.config_path
         msg_path = ConfigClass.custom_path
         user_config_file = f'{user_config_path}/config.ini'
-        token_warn_need_refresh = 30  # refresh token if token is about to expire
+        token_warn_need_refresh = 250  # refresh token if token is about to expire
         token_refresh_interval = 120  # auto refresh token every 2 minutes
 
         # NOTE: there is a limitation on minio that


### PR DESCRIPTION
## Summary

since the function `upload_client.set_finish_upload()` is in the main thread, it will be invoked immediately after `ThreadPool` prepare all the async calls. It means the `upload_client.set_finish_upload()` will be called even some of chunks are uploading. It will cause the invalid token when uploading large file.

## JIRA Issues

PILOT-2379

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


