### PR TITLE
PILOT-2678: Fix error message for dataset version download when versi…

### DIFF
--- a/app/services/dataset_manager/dataset_download.py
+++ b/app/services/dataset_manager/dataset_download.py
@@ -43,15 +43,14 @@ class SrvDatasetDownloadManager(metaclass=MetaService):
             'Session-ID': self.session_id,
         }
         payload = {'version': self.version}
-        try:
-            response = requests.get(url, headers=headers, params=payload)
-            res = response.json()
-            code = res.get('code')
-            if code == 404:
-                SrvErrorHandler.customized_handle(ECustomizedError.VERSION_NOT_EXIST, True, self.version)
-            else:
-                return res
-        except Exception:
+        response = requests.get(url, headers=headers, params=payload)
+        res = response.json()
+        code = response.status_code
+        if code == 200:
+            return res
+        elif code == 404:
+            SrvErrorHandler.customized_handle(ECustomizedError.VERSION_NOT_EXIST, True, self.version)
+        else:
             SrvErrorHandler.default_handle(response.content, True)
 
     @require_valid_token()


### PR DESCRIPTION
…on does not exist

## Summary

Fix the error message for dataset version download when version does not exist. This is because when doing the error handling during the version checking, the json response of dataset get version API no longer contains the code. Changing to the response.status_code instead

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-2678

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
