### PR TITLE
PILOT-2676: Fix project file listing white page error

### DIFF
--- a/app/services/file_manager/file_list.py
+++ b/app/services/file_manager/file_list.py
@@ -67,9 +67,10 @@ class SrvFileList(metaclass=MetaService):
     def list_files_with_pagination(self, paths, zone, page, page_size):
         while True:
             files = self.list_files(paths, zone, page, page_size)
-            if len(files) < page_size and page == 0:
-                break
-            elif len(files) < page_size and page != 0:
+            file_list = files.split('...')[:-1] if files != '' else []
+            if len(file_list) < page_size and page == 0:
+                choice = ['exit']
+            elif len(file_list) < page_size and page != 0:
                 choice = ['previous page', 'exit']
             elif page == 0:
                 choice = ['next page', 'exit']


### PR DESCRIPTION
## Summary
Try to fix the project file listing with the page change error. The file listing with page change always result in a blank page at the end. This is because the check file length, it checks the length of the string which corresponds to the length of the file folder name instead of the number of files and folders.

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-2676

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [ ] No

## Test Directions

Have tested on local for this pagination issue
