### PR TITLE
fixup the preupload will recieve the source_id as None

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -195,7 +195,7 @@ def file_put(**kwargs):  # noqa: C901
             'attribute': attribute,
         }
         if source_file:
-            upload_event['source_id'] = src_file_info.get('id')
+            upload_event['source_id'] = src_file_info.get('id', '')
 
         item_ids = simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
 

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -123,7 +123,7 @@ def simple_upload(  # noqa: C901
     create_folder_flag = upload_event.get('create_folder_flag', False)
     compress_zip = upload_event.get('compress_zip', False)
     regular_file = upload_event.get('regular_file', True)
-    source_id = upload_event.get('source_id', None)
+    source_id = upload_event.get('source_id', '')
     attribute = upload_event.get('attribute')
 
     mhandler.SrvOutPutHandler.start_uploading(input_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "2.3.1"
+version = "2.3.2"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Research"]
 


### PR DESCRIPTION
## Summary

hotfix the `source_id` will be None when not specify the source options. It will cause pre-upload api return 422 which `source_id` cannot be None type

## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
