### PR TITLE
PILOT_2779: fixup the core zone cannot resume the upload

### DIFF
--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -117,7 +117,7 @@ def simple_upload(  # noqa: C901
     tags = upload_event.get('tags')
     zone = upload_event.get('zone')
     # process_pipeline = upload_event.get('process_pipeline', None)
-    # upload_message = upload_event.get('upload_message')
+    upload_message = upload_event.get('upload_message')
     current_folder_node = upload_event.get('current_folder_node', '')
     parent_folder_id = upload_event.get('parent_folder_id', '')
     create_folder_flag = upload_event.get('create_folder_flag', False)
@@ -155,6 +155,7 @@ def simple_upload(  # noqa: C901
         regular_file=regular_file,
         tags=tags,
         source_id=source_id,
+        upload_message=upload_message,
     )
 
     # format the local path into object storage path for preupload

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -224,6 +224,7 @@ class UploadClient:
             'parent_folder_id': self.parent_folder_id,
             'current_folder_node': self.current_folder_node,
             'tags': self.tags,
+            'upload_message': self.upload_message,
             'file_objects': {file_object.item_id: file_object.to_dict() for file_object in file_objects},
         }
 


### PR DESCRIPTION
## Summary

The issue is cause by `upload_message` isn't provide by manifest file. To fix it, the normal upload will also output the `upload message` in the manifest file

## JIRA Issues

PILOT_2779

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


