### PR TITLE
PILOT-2809: update the lineage to use core zone file instead of greenroom

### DIFF
--- a/app/services/file_manager/file_upload/upload_validator.py
+++ b/app/services/file_manager/file_upload/upload_validator.py
@@ -29,7 +29,7 @@ class UploadEventValidator:
                 ECustomizedError.INVALID_UPLOAD_REQUEST, True, value='upload-message is required'
             )
         if self.source:
-            source_file_info = search_item(self.project_code, AppConfig.Env.green_zone.lower(), self.source, 'file')
+            source_file_info = search_item(self.project_code, AppConfig.Env.core_zone.lower(), self.source, 'file')
             source_file_info = source_file_info['result']
             if not source_file_info:
                 SrvErrorHandler.customized_handle(ECustomizedError.INVALID_SOURCE_FILE, True, value=self.source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "2.4.0a0"
+version = "2.4.1"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Research"]
 


### PR DESCRIPTION
## Summary

With the workflow update, the lineage feature for cli (ONLY) will specify the file in the core zone instead of greenroom. This operation is not treated as `copy_to_core`. There will be another type in the metadata service. Also the upload service should be updated as well

## JIRA Issues

PILOT-2809

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


