### PR TITLE
Pilot 2936: add an action to create the cli with mac version

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ needs.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
           asset_name: pilotcli
           asset_content_type: application/octet-stream
@@ -150,7 +150,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ needs.push-binary-linux.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
           asset_name: pilotcli
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -32,6 +32,9 @@ jobs:
     outputs:
       upload_url: ${{steps.extract_branch.outputs.upload_url}}
     steps:
+      - name: Set version in env
+        run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -84,8 +87,8 @@ jobs:
       - name: Build binary
         run: poetry run pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
 
-      - name: Set version in env
-        run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
+      # - name: Set version in env
+      #   run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
 
       # - name: Create Release
       #   id: create_release
@@ -147,8 +150,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
-      - name: Build binary
-        run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
+      # - name: Build binary
+      #   run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
 
       # - name: Create Release
       #   id: create_release

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -32,6 +32,19 @@ jobs:
     outputs:
       upload_url: ${{steps.extract_branch.outputs.upload_url}}
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9.16
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
       - name: Set version in env
         run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -129,8 +129,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
-      # - name: Build binary
-      #   run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
+      - name: Build binary
+        run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
 
       # - name: Create Release
       #   id: create_release
@@ -151,6 +151,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.push-binary-linux.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./app/bundled_app/linux/${{ github.sha }}
+          asset_path: ./app/bundled_app/macos/${{ github.sha }}
           asset_name: pilotcli_macos
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,7 +5,6 @@ on:
     workflows: [ "Run Tests" ]
     branches:
       - develop
-      - PILOT-2936
     types:
       - completed
   push:
@@ -26,7 +25,7 @@ jobs:
 
   push-binary-linux:
     needs: [ extract-branch-name ]
-    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'}}
     runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{steps.create_release.outputs.upload_url}}
@@ -94,7 +93,7 @@ jobs:
 
   push-binary-macos:
     needs: [ push-binary-linux ]
-    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'  || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'}}
     runs-on: macos-12
     steps:
       - name: Checkout repository
@@ -131,18 +130,6 @@ jobs:
 
       - name: Build binary
         run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
-
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      #   with:
-      #     tag_name: ${{ env.TAG_VERSION }}
-      #     release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
-      #     body: ${{ github.event.head_commit.message }}
-      #     draft: false
-      #     prerelease: false
 
       - name: Upload Release Binary
         id: upload-release-binary

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
     runs-on: ubuntu-20.04
     outputs:
-      upload_url: ${{steps.extract_branch.outputs.upload_url}}
+      upload_url: ${{steps.create_release.outputs.upload_url}}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
-          asset_name: pilotcli
+          asset_name: pilotcli_linux
           asset_content_type: application/octet-stream
 
   push-binary-macos:
@@ -152,5 +152,5 @@ jobs:
         with:
           upload_url: ${{ needs.push-binary-linux.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
-          asset_name: pilotcli
+          asset_name: pilotcli_macos
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,11 +5,13 @@ on:
     workflows: [ "Run Tests" ]
     branches:
       - develop
+      - PILOT-2936
     types:
       - completed
   push:
     branches:
       - main
+      - PILOT-2936
 
 jobs:
   extract-branch-name:
@@ -21,8 +23,29 @@ jobs:
         id: extract_branch
         shell: bash
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-  push-binary:
+
+
+  create-release:
     needs: [ extract-branch-name ]
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'  || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
+    runs-on: ubuntu-20.04
+    outputs:
+      upload_url: ${{steps.extract_branch.outputs.upload_url}}
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.TAG_VERSION }}
+          release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
+          body: ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+
+  push-binary-linux:
+    needs: [ create-release ]
     if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' }}
     runs-on: ubuntu-20.04
     steps:
@@ -64,17 +87,17 @@ jobs:
       - name: Set version in env
         run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ env.TAG_VERSION }}
-          release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
+      # - name: Create Release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      #   with:
+      #     tag_name: ${{ env.TAG_VERSION }}
+      #     release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
+      #     body: ${{ github.event.head_commit.message }}
+      #     draft: false
+      #     prerelease: false
 
       - name: Upload Release Binary
         id: upload-release-binary
@@ -82,7 +105,70 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./app/bundled_app/linux/${{ github.sha }}
+          asset_name: pilotcli
+          asset_content_type: application/octet-stream
+
+  push-binary-macos:
+    needs: [ create-release, push-binary-linux ]
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'  || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.extract-branch-name.outputs.branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9.16
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Set up cache
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Ensure cache is healthy
+        if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
+        run: timeout 10s poetry run pip --version || rm -rf .venv
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Build binary
+        run: poetry run pyinstaller -F --distpath ./app/bundled_app/macos --specpath ./app/build/macos --workpath ./app/build/macos --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
+
+      # - name: Create Release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      #   with:
+      #     tag_name: ${{ env.TAG_VERSION }}
+      #     release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
+      #     body: ${{ github.event.head_commit.message }}
+      #     draft: false
+      #     prerelease: false
+
+      - name: Upload Release Binary
+        id: upload-release-binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
           asset_name: pilotcli
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -93,7 +93,7 @@ jobs:
           asset_content_type: application/octet-stream
 
   push-binary-macos:
-    needs: [ create-release, push-binary-linux ]
+    needs: [ push-binary-linux ]
     if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'  || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
     runs-on: macos-12
     steps:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
   push-binary-linux:
     needs: [ extract-branch-name ]
-    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' }}
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
     runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{steps.extract_branch.outputs.upload_url}}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,46 +24,12 @@ jobs:
         shell: bash
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
-
-  create-release:
+  push-binary-linux:
     needs: [ extract-branch-name ]
-    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'  || needs.extract-branch-name.outputs.branch == 'PILOT-2936' }}
+    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' }}
     runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{steps.extract_branch.outputs.upload_url}}
-    steps:
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9.16
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.3.2
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Set version in env
-        run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ env.TAG_VERSION }}
-          release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
-
-  push-binary-linux:
-    needs: [ create-release ]
-    if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop' }}
-    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -100,20 +66,20 @@ jobs:
       - name: Build binary
         run: poetry run pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --paths=./.venv/lib/python3.9/site-packages ./app/pilotcli.py -n ${{ github.sha }}
 
-      # - name: Set version in env
-      #   run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
+      - name: Set version in env
+        run: poetry run echo "TAG_VERSION=`poetry version --short`" >> $GITHUB_ENV
 
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      #   with:
-      #     tag_name: ${{ env.TAG_VERSION }}
-      #     release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
-      #     body: ${{ github.event.head_commit.message }}
-      #     draft: false
-      #     prerelease: false
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.TAG_VERSION }}
+          release_name: Release ${{ needs.extract-branch-name.outputs.branch }} ${{ env.TAG_VERSION }}
+          body: ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
 
       - name: Upload Release Binary
         id: upload-release-binary

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./app/bundled_app/linux/${{ github.sha }}
           asset_name: pilotcli
           asset_content_type: application/octet-stream

--- a/app/resources/custom_help.py
+++ b/app/resources/custom_help.py
@@ -6,7 +6,7 @@
 class HelpPage:
     page = {
         'update': {
-            'version': '2.4.0',
+            'version': '2.4.2',
             '1': 'The logic of normal upload and resumble are splited. '
             'add new command for resumable upload as `pilotcli file resume -r manifest.json`',
             '2': 'The manifest file will be output for both file/folder upload',

--- a/app/resources/custom_help.py
+++ b/app/resources/custom_help.py
@@ -6,7 +6,7 @@
 class HelpPage:
     page = {
         'update': {
-            'version': '2.4.2',
+            'version': '2.4.3',
             '1': 'The logic of normal upload and resumble are splited. '
             'add new command for resumable upload as `pilotcli file resume -r manifest.json`',
             '2': 'The manifest file will be output for both file/folder upload',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "2.4.1"
+version = "2.4.2"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Research"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "2.4.2"
+version = "2.4.3"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Research"]
 


### PR DESCRIPTION
## Summary

now portal supports to download cli with linux and mac version. To allow building latest mac version, the git action will need to run the build on the mac machine.

## JIRA Issues

Pilot 2936

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
