### PR TITLE
PILOT-3234: update the config creation logic to avoid the injection

### DIFF
--- a/app/configs/user_config.py
+++ b/app/configs/user_config.py
@@ -5,6 +5,7 @@
 import configparser
 import os
 import time
+from pathlib import Path
 
 from app.configs.app_config import AppConfig
 from app.models.singleton import Singleton
@@ -24,7 +25,7 @@ class UserConfig(metaclass=Singleton):
         if not os.path.exists(AppConfig.Env.user_config_path):
             os.makedirs(AppConfig.Env.user_config_path)
         if not os.path.exists(AppConfig.Env.user_config_file):
-            os.system(r'touch {}'.format(AppConfig.Env.user_config_file))
+            Path.touch(Path(AppConfig.Env.user_config_file))
         self.config = configparser.ConfigParser()
         self.config.read(AppConfig.Env.user_config_file)
         if not self.config.has_section('USER'):


### PR DESCRIPTION
## Summary

The old logic of configuration directly use the `os.system()` to execute the `touch {}` command, which will cause the potential risk of script injection. To avoid this, replace the system command with python pathlib library.

## JIRA Issues

PILOT-3234

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


