### PR TITLE
PILOT-3280: add the error handler to search_item function

### DIFF
--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -45,7 +45,7 @@ def search_item(project_code, zone, folder_relative_path, item_type, container_t
     if res.status_code == 403:
         SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, project_code)
     elif res.status_code != 200:
-        SrvErrorHandler.default_handle(res.content, True)
+        SrvErrorHandler.default_handle(res.text, True)
 
     return res.json()
 

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -70,7 +70,7 @@ def test_search_file_error_handling_with_403(requests_mock, mocker, capsys):
         search_item(test_project_code, 'zone', 'folder_relative_path', 'file', 'project')
     out, _ = capsys.readouterr()
     assert (
-        out.rstrip('\n')
+        out.rstrip()
         == 'Permission denied. Please verify your role in the Project has permission to perform this action.'
     )
 
@@ -85,5 +85,5 @@ def test_search_file_error_handling_with_401(requests_mock, mocker, capsys):
     with pytest.raises(SystemExit):
         search_item(test_project_code, 'zone', 'folder_relative_path', 'file', 'project')
     out, _ = capsys.readouterr()
-    out = out.rstrip('\n').replace('b\'', '').replace('\'', '')
+    out = out.rstrip()
     assert out == 'Authentication failed.'


### PR DESCRIPTION
## Summary

the function does not properly handle the error other than 403. to fix this, add a elif to handle the error != 200

## JIRA Issues

PILOT-3280

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
