### PR TITLE
PILOT-3280: add new error handler for 404 when search item

### DIFF
--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -39,6 +39,8 @@ def search_item(project_code, zone, folder_relative_path, item_type, container_t
     res = requests.get(url, params=params, headers=headers)
     if res.status_code == 403:
         SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, project_code)
+    elif res.status_code == 404:
+        return {}
     elif res.status_code != 200:
         SrvErrorHandler.default_handle(res.text, True)
 

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -75,6 +75,18 @@ def test_search_file_error_handling_with_403(requests_mock, mocker, capsys):
     )
 
 
+def test_search_file_error_handling_with_404(requests_mock, mocker, capsys):
+    mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
+    requests_mock.get(
+        f'http://bff_cli/v1/project/{test_project_code}/search',
+        json={},
+        status_code=404,
+    )
+
+    res = search_item(test_project_code, 'zone', 'folder_relative_path', 'file', 'project')
+    assert res == {}
+
+
 def test_search_file_error_handling_with_401(requests_mock, mocker, capsys):
     mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
     requests_mock.get(


### PR DESCRIPTION
## Summary

A dedicate `404` error handling is required when specified path doesn't exist in the database

## JIRA Issues

PILOT-3280

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

new test case wheen 404 is returned
