### PR TITLE
PILOT-3493: Attribute automated release git tags to main branch

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -81,6 +81,7 @@ jobs:
           body: ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
+          target_commitish: main
           files: ./app/bundled_app/linux/pilotcli_linux
 
   push-binary-macos:


### PR DESCRIPTION
## Summary

Fix to attribute automated release tags into the main branch. It's currently pointing to develop instead which is not what's being built and deployed in the main branch.

## JIRA Issues

PILOT-3493

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)

1. Commit a unique version increment to the project definition with these changes included
2. Run the build and publish workflow. It should net you a new release with the git tag now getting attributed to the `main` branch instead of the default `develop` one