### PR TITLE
Hotfix20240527: fixup duplication check when uploading folder with cases insensitive updates

### DIFF
--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -167,7 +167,7 @@ class UploadClient:
         # generate a list of locations for uploaded files to check duplication
         # at same time, generate a dict of mapping with object_path: FileObject
         locations = [x.object_path for x in file_objects]
-        object_path_file_object_map = {x.object_path: x for x in file_objects}
+        object_path_file_object_map = {x.object_path.lower(): x for x in file_objects}
 
         payload = {
             'locations': locations,
@@ -182,9 +182,15 @@ class UploadClient:
         if response.status_code == 200:
             exist_files = response.json().get('result', [])
             for exist_file_path in exist_files:
-                object_path_file_object_map.pop(exist_file_path)
+                object_path_file_object_map.pop(exist_file_path.lower())
         else:
             SrvErrorHandler.default_handle('Error when checking file duplication', if_exit=True)
+
+        # reconstruct non exist file objects which will be uploaded
+        # without lower() function.
+        return_list = {}
+        for _, item in object_path_file_object_map.items():
+            return_list.update({item.object_path: item})
 
         return list(object_path_file_object_map.values()), exist_files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.3"
+version = "3.0.4"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

With case insensitive updates, cli should be able to detect whether there are duplicated case insensitive files/folders under the path when uploading. And prompt up proper message to notify users

## JIRA Issues



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

adding test cases to simulate case insensitive object
