### PR TITLE
hotfix20240625: use apikey to refresh when refresh token expired

### DIFF
--- a/app/services/user_authentication/token_manager.py
+++ b/app/services/user_authentication/token_manager.py
@@ -13,6 +13,7 @@ from app.configs.user_config import UserConfig
 from app.models.service_meta_class import MetaService
 from app.services.output_manager.error_handler import ECustomizedError
 from app.services.output_manager.error_handler import SrvErrorHandler
+from app.services.user_authentication.user_login_logout import login_using_api_key
 
 
 class SrvTokenManager(metaclass=MetaService):
@@ -80,6 +81,8 @@ class SrvTokenManager(metaclass=MetaService):
         if response.status_code == 200:
             self.update_token(response.json()['access_token'], response.json()['refresh_token'])
         elif response.status_code == 401:
-            SrvErrorHandler.customized_handle(ECustomizedError.INVALID_TOKEN, if_exit=True)
+            is_valid = login_using_api_key(self.config.api_key)
+            if not is_valid:
+                SrvErrorHandler.customized_handle(ECustomizedError.INVALID_TOKEN, if_exit=True)
         else:
             SrvErrorHandler.default_handle(response.content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.8"
+version = "3.0.9"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/services/user_authentication/test_token_manager.py
+++ b/tests/app/services/user_authentication/test_token_manager.py
@@ -36,7 +36,12 @@ class TestSrvTokenManager:
             status_code=401,
         )
 
+        login_using_api_key_mock = mocker.patch(
+            'app.services.user_authentication.token_manager.login_using_api_key', return_value=False
+        )
+        out, _ = capsys.readouterr()
         with pytest.raises(SystemExit):
             manager.refresh('test_azp')
         out, _ = capsys.readouterr()
         assert out.rstrip() == 'Your login session has expired. Please try again or log in again.'
+        assert login_using_api_key_mock.call_count == 1


### PR DESCRIPTION
## Summary

use apikey to refresh when refresh token expired. After using apikey, there is an random bug showing `Your login session has expired. Please try again or log in again.`. Maybe it is caused by expired refresh token.

## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


