### PR TITLE
Patch20240702: temporary add apikey logic for refreshing access token

### DIFF
--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     config_file: str = 'config.ini'
 
     keycloak_device_client_id: str = 'cli'
-    keycloak_api_key_audience: Set[str] = {'api-key'}
+    keycloak_api_key_audience: Set[str] = {'cli'}
 
     vm_info: str = ''
 

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -4,6 +4,7 @@
 
 from functools import lru_cache
 from pathlib import Path
+from typing import Set
 
 from pydantic import computed_field
 from pydantic_settings import BaseSettings
@@ -20,6 +21,7 @@ class Settings(BaseSettings):
     config_file: str = 'config.ini'
 
     keycloak_device_client_id: str = 'cli'
+    keycloak_api_key_audience: Set[str] = {'api-key'}
 
     vm_info: str = ''
 

--- a/app/services/user_authentication/token_manager.py
+++ b/app/services/user_authentication/token_manager.py
@@ -10,9 +10,11 @@ import requests
 from app.configs.app_config import AppConfig
 from app.configs.config import ConfigClass
 from app.configs.user_config import UserConfig
+from app.models.enums import LoginMethod
 from app.models.service_meta_class import MetaService
 from app.services.output_manager.error_handler import ECustomizedError
 from app.services.output_manager.error_handler import SrvErrorHandler
+from app.services.user_authentication.user_login_logout import exchange_api_key
 from app.services.user_authentication.user_login_logout import login_using_api_key
 
 
@@ -40,6 +42,13 @@ class SrvTokenManager(metaclass=MetaService):
         tokens = self.get_token()
         return jwt.decode(tokens[1], options={'verify_signature': False}, algorithms=['RS256'])
 
+    def is_api_key(self) -> bool:
+        token = self.decode_access_token()
+        audience = token['aud']
+        if isinstance(audience, str):
+            audience = [audience]
+            return ConfigClass.keycloak_api_key_audience.issubset(set(audience))
+
     def check_valid(self, required_azp):
         """
         check token validation
@@ -52,19 +61,22 @@ class SrvTokenManager(metaclass=MetaService):
         now = time.time()
         diff = expiry_at - now
 
-        azp_token_condition = decoded_access_token['azp'] not in [
-            required_azp,
-            ConfigClass.keycloak_device_client_id,
-        ]
+        if not self.is_api_key():
+            azp_token_condition = decoded_access_token['azp'] not in [
+                required_azp,
+                ConfigClass.keycloak_device_client_id,
+            ]
 
-        if azp_token_condition or expiry_at <= now:
-            return 2
+            if azp_token_condition or expiry_at <= now:
+                return 2
 
         if diff <= AppConfig.Env.token_warn_need_refresh:
             return 1
         return 0
 
     def refresh(self, azp: str) -> None:
+        if self.is_api_key():
+            return self.refresh_api_key()
 
         url = AppConfig.Connections.url_keycloak_token
         payload = {
@@ -86,3 +98,11 @@ class SrvTokenManager(metaclass=MetaService):
                 SrvErrorHandler.customized_handle(ECustomizedError.INVALID_TOKEN, if_exit=True)
         else:
             SrvErrorHandler.default_handle(response.content)
+
+    def refresh_api_key(self) -> None:
+        access_token, _ = exchange_api_key(self.config.api_key)
+        if access_token is None:
+            return SrvErrorHandler.default_handle(
+                f'Unable to get access token using "{LoginMethod.API_KEY.value}" method. Unable to proceed.', True
+            )
+        self.update_token(access_token, '')

--- a/app/services/user_authentication/token_manager.py
+++ b/app/services/user_authentication/token_manager.py
@@ -45,9 +45,9 @@ class SrvTokenManager(metaclass=MetaService):
     def is_api_key(self) -> bool:
         token = self.decode_access_token()
         audience = token['aud']
-        if isinstance(audience, str):
-            audience = [audience]
+        if isinstance(audience, list):
             return ConfigClass.keycloak_api_key_audience.issubset(set(audience))
+        return False
 
     def check_valid(self, required_azp):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.9"
+version = "3.0.10a0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.10a0"
+version = "3.0.9a0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/services/user_authentication/test_token_manager.py
+++ b/tests/app/services/user_authentication/test_token_manager.py
@@ -12,17 +12,19 @@ from tests.conftest import decoded_token
 
 
 class TestSrvTokenManager:
-    def test_refresh_calls_refresh_token_method_when_is_api_key_method_returns_true(self, requests_mock, fake):
+    def test_refresh_calls_refresh_token_method_when_is_api_key_method_returns_true(self, requests_mock, fake, mocker):
         user_config = UserConfig()
         user_config.access_token = jwt.encode({'aud': 'api-key'}, key='')
         user_config.refresh_token = jwt.encode({'refresh': 'token'}, key='')
         manager = SrvTokenManager()
+        refresh_api_key_mock = mocker.patch.object(manager, 'refresh_api_key')
         requests_mock.post(
             AppConfig.Connections.url_keycloak_token,
             json={'access_token': user_config.access_token, 'refresh_token': user_config.refresh_token},
         )
 
         manager.refresh(fake.pystr())
+        assert refresh_api_key_mock.call_count == 1
 
     def test_refresh_failed_with_invalid_token(self, requests_mock, mocker, settings, capsys):
         manager = SrvTokenManager()

--- a/tests/app/services/user_authentication/test_token_manager.py
+++ b/tests/app/services/user_authentication/test_token_manager.py
@@ -17,6 +17,7 @@ class TestSrvTokenManager:
         user_config.access_token = jwt.encode({'aud': 'api-key'}, key='')
         user_config.refresh_token = jwt.encode({'refresh': 'token'}, key='')
         manager = SrvTokenManager()
+        mocker.patch.object(manager, 'is_api_key', return_value=True)
         refresh_api_key_mock = mocker.patch.object(manager, 'refresh_api_key')
         requests_mock.post(
             AppConfig.Connections.url_keycloak_token,


### PR DESCRIPTION
## Summary

Due to some repetitive error from bd2data, we decide to temporary add back api-key logic for refresh access token instead of refresh token.

referring previous PR: https://github.com/PilotDataPlatform/cli/pull/144

## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add mock back
