### PR TITLE
Hotfix20240710: hotfix the api key detection is using wrong aud and cause reversed behavior

### DIFF
--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     config_file: str = 'config.ini'
 
     keycloak_device_client_id: str = 'cli'
-    keycloak_api_key_audience: Set[str] = {'cli'}
+    keycloak_api_key_audience: Set[str] = {'api-key'}
 
     vm_info: str = ''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.9a2"
+version = "3.0.9a3"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

by reverting keycloak extension, the correct `aud` for checking api-key enabling should be `api-key` not `cli`

https://github.com/PilotDataPlatform/cli/commit/ce4671d59fad44c2f8865920c4bac8f3f577ffea#diff-3269a12c9baae202e3d5d91cc06ed8d9f443b4025a4ce7feb593d924d1f93b8bL24

## JIRA Issues



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions


