### PR TITLE
Pilot 5192: change version check logic to use download service api

### DIFF
--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -5,6 +5,8 @@
 from typing import Union
 
 import click
+import pkg_resources
+from packaging.version import Version
 
 import app.services.output_manager.help_page as user_help
 import app.services.output_manager.message_handler as mhandler
@@ -15,6 +17,7 @@ from app.services.user_authentication.user_login_logout import user_device_id_lo
 from app.services.user_authentication.user_login_logout import user_logout
 from app.services.user_authentication.user_login_logout import validate_user_device_login
 from app.utils.aggregated import doc
+from app.utils.aggregated import get_latest_cli_version
 
 
 @click.command()
@@ -54,6 +57,11 @@ def login(api_key: Union[str, None]):
             mhandler.SrvOutPutHandler.login_success()
         else:
             mhandler.SrvOutPutHandler.validation_login_input_device_error()
+
+    # message user if there is a newer version of the CLI
+    latest_version = get_latest_cli_version()
+    if Version(pkg_resources.get_distribution('app').version) < latest_version:
+        mhandler.SrvOutPutHandler.newer_version_available(latest_version)
 
 
 @click.command()

--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -2,6 +2,7 @@
 #
 # Contact Indoc Systems for any questions regarding the use of this source code.
 
+import sys
 from typing import Union
 
 import click
@@ -41,6 +42,7 @@ def login(api_key: Union[str, None]):
             mhandler.SrvOutPutHandler.login_success()
         else:
             mhandler.SrvOutPutHandler.login_using_api_key_failed_error()
+            sys.exit(1)
     else:
         mhandler.SrvOutPutHandler.login_using_method(LoginMethod.DEVICE_CODE)
         device_login = user_device_id_login()
@@ -49,6 +51,7 @@ def login(api_key: Union[str, None]):
             mhandler.SrvOutPutHandler.login_device_code_qrcode(device_login['verification_uri_complete'])
         else:
             mhandler.SrvOutPutHandler.login_input_device_error()
+            sys.exit(1)
 
         is_validated = validate_user_device_login(
             device_login['device_code'], device_login['expires'], device_login['interval']
@@ -57,6 +60,7 @@ def login(api_key: Union[str, None]):
             mhandler.SrvOutPutHandler.login_success()
         else:
             mhandler.SrvOutPutHandler.validation_login_input_device_error()
+            sys.exit(1)
 
     # message user if there is a newer version of the CLI
     latest_version = get_latest_cli_version()

--- a/app/configs/user_config.py
+++ b/app/configs/user_config.py
@@ -126,6 +126,9 @@ class UserConfig(metaclass=Singleton):
     def is_logged_in(self) -> bool:
         return bool(self.api_key or (self.access_token and self.refresh_token))
 
+    def is_access_token_exists(self) -> bool:
+        return len(self.config['USER']['access_token']) > 0
+
     @property
     def username(self):
         return decryption(self.config['USER']['username'], self.secret)

--- a/app/pilotcli.py
+++ b/app/pilotcli.py
@@ -5,16 +5,27 @@
 from multiprocessing import freeze_support
 
 import click
+import pkg_resources
 import requests
+from packaging.version import Version
 
 import app.services.output_manager.error_handler as error_handler
+import app.services.output_manager.message_handler as mhandler
 from app.commands.entry_point import command_groups
 from app.commands.entry_point import entry_point
 from app.services.output_manager.help_page import get_cli_help_message
 from app.utils.aggregated import doc
+from app.utils.aggregated import get_latest_cli_version
 
 
 class ComplexCLI(click.MultiCommand):
+    def format_help_text(self, ctx, formatter):
+        latest_version = get_latest_cli_version()
+        if Version(pkg_resources.get_distribution('app').version) < latest_version:
+            self.help += mhandler.SrvOutPutHandler.newer_version_available(latest_version, False)
+
+        click.MultiCommand.format_help_text(self, ctx, formatter)
+
     def list_commands(self, ctx):
         rv = command_groups()
         rv.sort()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.9a2"
+version = "3.0.9"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

with previous updates https://github.com/PilotDataPlatform/cli/pull/146, we found out GITHUB repo has a huge limitation of 60 unauthorized request per hour. To resolve this issue, we decide to use our own download link presented by download service which will also return version number.

## JIRA Issues

Pilot 5192

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

change the mock to download service
