### PR TITLE
Patch20240717: add BaseClient to unify http request

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -185,8 +185,6 @@ def file_put(**kwargs):  # noqa: C901
         if not upload_message:
             upload_message = AppConfig.Env.default_upload_message
 
-    return
-
     # for the path formating there will be following cases:
     # - file:
     #   1. the project path exist, then will be AS_FILE. nothing will be changed.

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -185,6 +185,8 @@ def file_put(**kwargs):  # noqa: C901
         if not upload_message:
             upload_message = AppConfig.Env.default_upload_message
 
+    return
+
     # for the path formating there will be following cases:
     # - file:
     #   1. the project path exist, then will be AS_FILE. nothing will be changed.

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -2,6 +2,7 @@
 #
 # Contact Indoc Systems for any questions regarding the use of this source code.
 
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Set
@@ -16,6 +17,7 @@ class Settings(BaseSettings):
 
     project: str = 'pilot'
     app_name: str = 'pilotcli'
+    log_level: str = 'WARNING'
 
     config_path: str = str(Path.home() / f'.{app_name}')
     config_file: str = 'config.ini'
@@ -30,6 +32,11 @@ class Settings(BaseSettings):
 
     api_url: str = 'https://api.pilot.indocresearch.com/pilot'
     keycloak_realm_url: str = 'https://iam.pilot.indocresearch.com/realms/pilot'
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        logging.basicConfig(level=self.log_level)
 
     @computed_field
     def url_bff(self) -> str:

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
 
     project: str = 'pilot'
     app_name: str = 'pilotcli'
-    log_level: str = 'WARNING'
+    log_level: str = 'DEBUG'
 
     config_path: str = str(Path.home() / f'.{app_name}')
     config_file: str = 'config.ini'

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
 
     project: str = 'pilot'
     app_name: str = 'pilotcli'
-    log_level: str = 'DEBUG'
+    log_level: str = 'ERROR'
 
     config_path: str = str(Path.home() / f'.{app_name}')
     config_file: str = 'config.ini'

--- a/app/services/clients/__init__.py
+++ b/app/services/clients/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.

--- a/app/services/clients/base_client.py
+++ b/app/services/clients/base_client.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import logging
+from typing import Any
+from typing import Mapping
+from typing import Optional
+
+from httpx import Client
+from httpx import RequestError
+from httpx import Response
+
+from app.configs.config import ConfigClass
+
+logger = logging.getLogger('pilot.cli.base_client')
+
+
+class BaseClient:
+    """Client for any inherited service clients."""
+
+    def __init__(self, endpoint: str, timeout: int) -> None:
+        self.endpoint_v1 = f'{endpoint}/v1'
+        self.client = Client(headers={'VM-Info': ConfigClass.vm_info}, timeout=timeout)
+
+    async def _request(
+        self, method: str, url: str, json: Optional[Any] = None, params: Optional[Mapping[str, Any]] = None
+    ) -> Response:
+        """Make http request."""
+
+        try:
+            response = await self.client.request(method, url, json=json, params=params)
+            logger.info(f'Request "{method} {url}" and params {params} received status {response.status_code}.')
+        except RequestError:
+            message = f'Unable to query data from auth service with url "{method} {url}" and params "{params}".'
+            logger.exception(message)
+            raise Exception(message)
+
+        return response
+
+    async def _get(self, url: str, params: Optional[Mapping[str, Any]] = None) -> Response:
+        """Send GET request."""
+
+        return await self._request('GET', url, params=params)
+
+    async def _post(self, url: str, json: Optional[Any] = None, params: Optional[Mapping[str, Any]] = None) -> Response:
+        """Send POST request."""
+
+        return await self._request('POST', url, json=json, params=params)
+
+    async def _put(self, url: str, json: Optional[Any] = None, params: Optional[Mapping[str, Any]] = None) -> Response:
+        return await self._request('PUT', url, json=json, params=params)
+
+    async def _delete(
+        self, url: str, params: Optional[Mapping[str, Any]] = None, json: Optional[Any] = None
+    ) -> Response:
+        """Send DELETE request."""
+
+        return await self._request('DELETE', url, params=params, json=json)
+
+    async def _patch(
+        self, url: str, json: Optional[Any] = None, params: Optional[Mapping[str, Any]] = None
+    ) -> Response:
+        """Send PATCH request."""
+
+        return await self._request('PATCH', url, json=json, params=params)

--- a/app/services/clients/base_client.py
+++ b/app/services/clients/base_client.py
@@ -23,7 +23,7 @@ class BaseClient:
     """Client for any inherited service clients."""
 
     user = UserConfig()
-    token_manager = SrvTokenManager()
+    token_manager: SrvTokenManager
 
     def __init__(self, endpoint: str, timeout: int = 10) -> None:
         self.endpoint_v1 = f'{endpoint}/v1'
@@ -32,6 +32,7 @@ class BaseClient:
         self.retry_status = [401, 503]
         self.retry_count = 3
         self.retry_interval = 0.1
+        self.token_manager = SrvTokenManager()
 
     def _request(
         self, method: str, url: str, json: Optional[Any] = None, params: Optional[Mapping[str, Any]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.11"
+version = "3.0.12"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.10"
+version = "3.0.11"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

cli has some legacy code with api request. Some of them are still usng `requests` package and other new features are using `httpx` package. To unify them, this PR adds a `BaseClient` for http request for RESTful APIs and a retry method when hit 401 `token invalid`

Also migrate attribute related functions to use `BaseClient` from `requests` package

## JIRA Issues

PILOT-5553

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)
