### PR TITLE
PILOT-2833: strip ending slash in project path when upload files

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -122,7 +122,7 @@ def file_put(**kwargs):  # noqa: C901
     """"""
 
     files = kwargs.get('files')
-    project_path = kwargs.get('project_path')
+    project_path = kwargs.get('project_path').strip('/')
     tag_files = kwargs.get('tag')
     zone = kwargs.get('zone')
     upload_message = kwargs.get('upload_message')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.0.12"
+version = "3.0.13"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -24,7 +24,8 @@ from app.services.output_manager.error_handler import customized_error_msg
 from tests.conftest import decoded_token
 
 
-def test_file_upload_command_success_with_attribute(mocker, cli_runner):
+@pytest.mark.parametrize('ending_slash', ['', '/'])
+def test_file_upload_command_success_with_attribute(mocker, cli_runner, ending_slash):
     mocker.patch('app.commands.file.validate_upload_event', return_value={'source_file': '', 'attribute': 'test'})
     mocker.patch('app.commands.file.assemble_path', return_value=('test', {'id': 'id'}, True, 'test'))
 
@@ -48,7 +49,7 @@ def test_file_upload_command_success_with_attribute(mocker, cli_runner):
             file_put,
             [
                 '--project-path',
-                f'test_project/{ItemType.NAMEFOLDER.get_prefix_by_type()}admin',
+                f'test_project/{ItemType.NAMEFOLDER.get_prefix_by_type()}admin' + ending_slash,
                 '--thread',
                 1,
                 '--attribute',


### PR DESCRIPTION
## Summary

strip the ending slash in project path when upload files. The ending slash will be treated as invalid input so `strip()` function will remove it and not trigger any error.

## JIRA Issues

PILOT-2833

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

adding a test for upload when use input ending slash
