### PR TITLE
PILOT-5849: fixup the folder download issue

### DIFF
--- a/app/services/file_manager/file_download/download_client.py
+++ b/app/services/file_manager/file_download/download_client.py
@@ -37,11 +37,14 @@ class SrvFileDownload(BaseAuthClient, metaclass=MetaService):
         self.hash_code = ''
         self.total_size = ''
         self.interactive = interactive
-        self.url = ''
         self.check_point = False
         self.core = self.appconfig.Env.core_zone
         self.green = self.appconfig.Env.green_zone
         self.zone = zone
+        self.url = {
+            ItemZone.GREENROOM.value: self.appconfig.Connections.url_download_greenroom,
+            ItemZone.CORE.value: self.appconfig.Connections.url_download_core,
+        }.get(zone)
 
         self.endpoint = self.appconfig.Connections.url_download_greenroom + '/v1'
 
@@ -127,7 +130,7 @@ class SrvFileDownload(BaseAuthClient, metaclass=MetaService):
         return status
 
     def generate_download_url(self):
-        download_url = self.url + f'v1/download/{self.hash_code}'
+        download_url = self.url + f'/v1/download/{self.hash_code}'
         return download_url
 
     def avoid_duplicate_file_name(self, filename):


### PR DESCRIPTION
## Summary

fixup download url formatting issue when downloading a folder.

## JIRA Issues

PILOT-5849

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add test cases for `simple_file_download` function
