### PR TITLE
Pilot 5871: adding new command to create folder under project

### DIFF
--- a/app/commands/entry_point.py
+++ b/app/commands/entry_point.py
@@ -24,6 +24,7 @@ from .file import file_metadata_download
 from .file import file_move
 from .file import file_put
 from .file import file_resume
+from .folder import folder_create
 
 # Import custom commands
 from .project import project_list_all
@@ -34,7 +35,7 @@ container_registry_enabled = os.environ.get('PILOT_CLI_CONTAINER_REGISTRY_ENABLE
 
 
 def command_groups():
-    commands = ['file', 'user', 'project', 'dataset']
+    commands = ['file', 'user', 'project', 'dataset', 'folder']
     if container_registry_enabled:
         commands.append('container_registry')
     return commands
@@ -68,6 +69,11 @@ def user_group():
     pass
 
 
+@entry_point.group(name='folder')
+def folder_group():
+    pass
+
+
 file_group.add_command(file_put)
 file_group.add_command(file_check_manifest)
 file_group.add_command(file_export_manifest)
@@ -82,6 +88,7 @@ user_group.add_command(logout)
 dataset_group.add_command(dataset_list)
 dataset_group.add_command(dataset_show_detail)
 dataset_group.add_command(dataset_download)
+folder_group.add_command(folder_create)
 
 # Custom commands
 if container_registry_enabled:

--- a/app/commands/folder.py
+++ b/app/commands/folder.py
@@ -51,4 +51,4 @@ def folder_create(object_path, zone):
 
     folder_client = FolderClient(project_code, zone)
     folder_client.create_folder(object_path)
-    message_handler.SrvOutPutHandler.folder_create(project_code, object_path)
+    message_handler.SrvOutPutHandler.folder_create(project_code, object_path, zone)

--- a/app/commands/folder.py
+++ b/app/commands/folder.py
@@ -24,7 +24,6 @@ def cli():
 
 
 @click.command(name='create')
-@click.argument('project_code', type=str)
 @click.argument('object_path', type=str)
 @click.option(
     '-z',
@@ -36,8 +35,10 @@ def cli():
     show_default=True,
 )
 @doc(folder_help_page(FolderHelp.FOLDER_CREATE))
-def folder_create(project_code, object_path, zone):
+def folder_create(object_path, zone):
     """"""
+    # object_path is composed of project_code and folder_name
+    project_code, object_path = object_path.split('/', 1)
 
     # user cannot create root/name/shared folder in cli
     # and folder name must NOT contain special characters[/:?.\\*<>|”\']

--- a/app/commands/folder.py
+++ b/app/commands/folder.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import click
+
+from app.configs.app_config import AppConfig
+from app.services.file_manager.file_metadata.folder_client import FolderClient
+from app.services.output_manager.help_page import FileHELP
+from app.services.output_manager.help_page import FolderHelp
+from app.services.output_manager.help_page import file_help_page
+from app.services.output_manager.help_page import folder_help_page
+from app.utils.aggregated import doc
+
+
+@click.command()
+def cli():
+    """folder Actions."""
+    pass
+
+
+@click.command(name='create')
+@click.argument('project_code', type=str)
+@click.argument('object_path', type=str)
+@click.option(
+    '-z',
+    '--zone',
+    type=click.Choice([AppConfig.Env.green_zone, AppConfig.Env.core_zone]),
+    default=AppConfig.Env.green_zone,
+    required=False,
+    help=file_help_page(FileHELP.FILE_Z),
+    show_default=True,
+)
+@doc(folder_help_page(FolderHelp.FOLDER_CREATE))
+def folder_create(project_code, object_path, zone):
+    """"""
+
+    if len(object_path.split('/')) <= 2:
+        click.echo('Please provide a valid path')
+        exit(1)
+
+    folder_client = FolderClient(project_code, zone)
+    folder_client.create_folder(object_path)
+    click.echo(f'Folder created: {object_path}')
+    click.echo('Done')

--- a/app/resources/custom_error.py
+++ b/app/resources/custom_error.py
@@ -124,4 +124,6 @@ class Error:
         'CONTAINER_REGISTRY_NO_URL': (
             'Container registry has not yet been configured. Related commands cannot be used at this time.'
         ),
+        # folder related error
+        'INVALID_FOLDER_PATH': 'Invalid folder path: cannot create name folder or shared folder in cli',
     }

--- a/app/resources/custom_help.py
+++ b/app/resources/custom_help.py
@@ -75,4 +75,7 @@ class HelpPage:
             'GET_SECRET': 'Get your user CLI secret',
             'SHARE_PROJECT': 'Share a project with another user',
         },
+        'folder': {
+            'FOLDER_CREATE': 'Create folders/subfolders in project.',
+        },
     }

--- a/app/services/file_manager/file_metadata/folder_client.py
+++ b/app/services/file_manager/file_metadata/folder_client.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import uuid
+
+from httpx import HTTPStatusError
+
+from app.configs.app_config import AppConfig
+from app.services.clients.base_auth_client import BaseAuthClient
+from app.services.output_manager.error_handler import SrvErrorHandler
+from app.utils.aggregated import check_item_duplication
+from app.utils.aggregated import search_item
+
+
+class FolderClient(BaseAuthClient):
+    def __init__(self, project_code: str, zone: str) -> None:
+        super().__init__(AppConfig.Connections.url_bff + '/v1')
+
+        self.project_code = project_code
+        self.zone = {'greenroom': 0, 'core': 1}.get(zone)
+
+    def _get_root_folder_id(self, root_folder: str) -> str:
+        # get the current exist name folder or shared folder for reference
+        exist_parent = root_folder
+        exist_parent_item = search_item(self.project_code, self.zone, exist_parent).get('result')
+        exist_parent_id = exist_parent_item.get('id')
+        if not exist_parent_id:
+            SrvErrorHandler.default_handle(f'Parent folder: {exist_parent} not exist', True)
+
+        return exist_parent_id
+
+    def create_folder(self, folder_path: str) -> dict:
+        """Create object path is not on platfrom.
+
+        it will create every non-exist folder along path.
+        """
+
+        path_list = folder_path.split('/')
+
+        # first check every folder in path exist or not
+        # the loop start with index 1 since we assume cli will not
+        # create any name folder or project folder
+        check_list = []
+        for index in range(2, len(path_list)):
+            check_list.append('/'.join(path_list[: index + 1]))
+        if len(check_list) == 0:
+            return
+
+        # confirm if user want to create folder or not
+        exist_path = check_item_duplication(check_list, self.zone, self.project_code)
+        not_exist_path = sorted(set(check_list) - set(exist_path))
+
+        exist_parent_id = self._get_root_folder_id(not_exist_path[0].rsplit('/', 1)[0])
+        to_create = {'folders': [], 'parent_id': exist_parent_id}
+        for path in not_exist_path:
+            parent_path, folder_name = path.rsplit('/', 1)
+            current_item_id = str(uuid.uuid4())
+            to_create['folders'].append(
+                {
+                    'name': folder_name,
+                    'parent': exist_parent_id,
+                    'parent_path': parent_path,
+                    'container_code': self.project_code,
+                    'container_type': 'project',
+                    'zone': self.zone,
+                    'item_id': current_item_id,
+                }
+            )
+            exist_parent_id = current_item_id
+
+        try:
+            response = self._post('folders/batch', json=to_create)
+        except HTTPStatusError as e:
+            response = e.response
+            SrvErrorHandler.default_handle(response.text, True)
+
+        return response.json().get('result')

--- a/app/services/file_manager/file_metadata/folder_client.py
+++ b/app/services/file_manager/file_metadata/folder_client.py
@@ -20,6 +20,7 @@ class FolderClient(BaseAuthClient):
 
         self.project_code = project_code
         self.zone = {'greenroom': 0, 'core': 1}.get(zone)
+        self.zone_str = zone
 
     def _get_root_folder_id(self, root_folder: str) -> str:
         # get the current exist name folder or shared folder for reference
@@ -52,7 +53,7 @@ class FolderClient(BaseAuthClient):
         exist_path = check_item_duplication(check_list, self.zone, self.project_code)
         not_exist_path = sorted(set(check_list) - set(exist_path))
         if not not_exist_path:
-            message_handler.SrvOutPutHandler.folder_duplicate_error(self.project_code, folder_path)
+            message_handler.SrvOutPutHandler.folder_duplicate_error(self.project_code, folder_path, self.zone_str)
             exit(1)
 
         exist_parent_id = self._get_root_folder_id(not_exist_path[0].rsplit('/', 1)[0])

--- a/app/services/file_manager/file_metadata/folder_client.py
+++ b/app/services/file_manager/file_metadata/folder_client.py
@@ -8,6 +8,7 @@ from httpx import HTTPStatusError
 
 from app.configs.app_config import AppConfig
 from app.services.clients.base_auth_client import BaseAuthClient
+from app.services.output_manager import message_handler
 from app.services.output_manager.error_handler import SrvErrorHandler
 from app.utils.aggregated import check_item_duplication
 from app.utils.aggregated import search_item
@@ -50,6 +51,9 @@ class FolderClient(BaseAuthClient):
         # confirm if user want to create folder or not
         exist_path = check_item_duplication(check_list, self.zone, self.project_code)
         not_exist_path = sorted(set(check_list) - set(exist_path))
+        if not not_exist_path:
+            message_handler.SrvOutPutHandler.folder_duplicate_error(self.project_code, folder_path)
+            exit(1)
 
         exist_parent_id = self._get_root_folder_id(not_exist_path[0].rsplit('/', 1)[0])
         to_create = {'folders': [], 'parent_id': exist_parent_id}

--- a/app/services/file_manager/file_metadata/folder_client.py
+++ b/app/services/file_manager/file_metadata/folder_client.py
@@ -45,7 +45,7 @@ class FolderClient(BaseAuthClient):
         for index in range(2, len(path_list)):
             check_list.append('/'.join(path_list[: index + 1]))
         if len(check_list) == 0:
-            return
+            return {}
 
         # confirm if user want to create folder or not
         exist_path = check_item_duplication(check_list, self.zone, self.project_code)

--- a/app/services/output_manager/error_handler.py
+++ b/app/services/output_manager/error_handler.py
@@ -84,6 +84,8 @@ class ECustomizedError(enum.Enum):
     CONTAINER_REGISTRY_NO_URL = 'CONTAINER_REGISTRY_NO_URL'
     CONFIG_INVALID_PERMISSIONS = 'CONFIG_INVALID_PERMISSIONS'
 
+    INVALID_FOLDER_PATH = 'INVALID_FOLDER_PATH'
+
 
 def customized_error_msg(customized_error: ECustomizedError):
     if customized_error.name == 'TOU_CONTENT':
@@ -112,4 +114,4 @@ class SrvErrorHandler(metaclass=MetaService):
         else:
             logger.error(customized_error_msg(customized_error))
         if if_exit:
-            sys.exit(0)
+            sys.exit(1)

--- a/app/services/output_manager/help_page.py
+++ b/app/services/output_manager/help_page.py
@@ -105,3 +105,12 @@ class ContainerRegistryHELP(enum.Enum):
 def cr_help_page(ContainerRegistryHELP: ContainerRegistryHELP):
     helps = help_msg.get('container_registry', 'default container_registry help')
     return helps.get(ContainerRegistryHELP.name)
+
+
+class FolderHelp(enum.Enum):
+    FOLDER_CREATE = 'FOLDER_CREATE'
+
+
+def folder_help_page(FolderHELP: FolderHelp):
+    helps = help_msg.get('folder', 'default folder help')
+    return helps.get(FolderHELP.name)

--- a/app/services/output_manager/message_handler.py
+++ b/app/services/output_manager/message_handler.py
@@ -349,3 +349,7 @@ class SrvOutPutHandler(metaclass=MetaService):
             logger.warning(message)
 
         return message
+
+    @staticmethod
+    def folder_create(project_code, object_path):
+        logger.info(f'Folder created: {object_path} at project: {project_code}')

--- a/app/services/output_manager/message_handler.py
+++ b/app/services/output_manager/message_handler.py
@@ -351,9 +351,9 @@ class SrvOutPutHandler(metaclass=MetaService):
         return message
 
     @staticmethod
-    def folder_create(project_code: str, object_path: str):
-        logger.info(f'Folder created: {object_path} at project: {project_code}')
+    def folder_create(project_code: str, object_path: str, zone: str):
+        logger.info(f'Folder created: {object_path} at project: {project_code} at zone: {zone}')
 
     @staticmethod
-    def folder_duplicate_error(project_code: str, object_path: str):
-        logger.error(f'Folder: {object_path} already exists in project: {project_code}')
+    def folder_duplicate_error(project_code: str, object_path: str, zone: str):
+        logger.error(f'Folder: {object_path} already exists in project: {project_code} at zone: {zone}')

--- a/app/services/output_manager/message_handler.py
+++ b/app/services/output_manager/message_handler.py
@@ -351,5 +351,9 @@ class SrvOutPutHandler(metaclass=MetaService):
         return message
 
     @staticmethod
-    def folder_create(project_code, object_path):
+    def folder_create(project_code: str, object_path: str):
         logger.info(f'Folder created: {object_path} at project: {project_code}')
+
+    @staticmethod
+    def folder_duplicate_error(project_code: str, object_path: str):
+        logger.error(f'Folder: {object_path} already exists in project: {project_code}')

--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -132,7 +132,7 @@ def get_zone(zone):
 
 
 def validate_folder_name(folder_name):
-    regex = re.compile('[/:?.\\*<>|”\']')
+    regex = re.compile(r'[/:?.\\*<>|”\']')
     contain_invalid_char = regex.search(folder_name)
     if contain_invalid_char or len(folder_name) > 100 or not folder_name:
         valid = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.1.0"
+version = "3.2.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -73,7 +73,7 @@ def test_file_upload_failed_with_invalid_tag_file(cli_runner):
         result = cli_runner.invoke(
             file_put, ['--project-path', 'test', '--thread', 1, '--tag', 'wrong_tag.json', 'wrong_tag.json']
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert result.output == customized_error_msg(ECustomizedError.INVALID_TAG_FILE) + '\n'
 
 
@@ -88,7 +88,7 @@ def test_file_upload_failed_with_invalid_attribute_file(cli_runner):
             file_put,
             ['--project-path', 'test', '--thread', 1, '--attribute', 'wrong_attribute.json', 'wrong_attribute.json'],
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert result.output == customized_error_msg(ECustomizedError.INVALID_TEMPLATE) + '\n'
 
 
@@ -137,7 +137,7 @@ def test_resumable_upload_command_failed_with_file_not_exists(mocker, cli_runner
     mocker.patch('os.path.exists', return_value=False)
 
     result = cli_runner.invoke(file_resume, ['--resumable-manifest', 'test.json', '--thread', 1])
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert result.output == customized_error_msg(ECustomizedError.INVALID_RESUMABLE) + '\n'
 
 

--- a/tests/app/commands/test_folder.py
+++ b/tests/app/commands/test_folder.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import pytest
+
+from app.commands.folder import folder_create
+
+
+def test_folder_create_success(mocker, cli_runner):
+    mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
+    mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
+
+    result = cli_runner.invoke(folder_create, ['testproject', 'users/testuser/testfolder'])
+    assert result.exit_code == 0
+
+
+def test_folder_create_invalid_folder_path(mocker, cli_runner):
+    mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
+    mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
+
+    result = cli_runner.invoke(folder_create, ['testproject', 'users/testuser'])
+    assert result.exit_code == 1
+    assert 'Invalid folder path' in result.output
+
+
+# test [/:?.\\*<>|”\']
+@pytest.mark.parametrize('invalid_char', [r'\\', '/', ':', '?', '.', '\'', '*', '<', '>', '|', '”'])
+def test_folder_create_invalid_folder_name(mocker, cli_runner, invalid_char):
+    mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
+    mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
+
+    result = cli_runner.invoke(folder_create, ['testproject', f'users/testuser/testfolder{invalid_char}'])
+
+    assert result.exit_code == 1
+    assert 'The input folder name is not valid. Please follow the rule:' in result.output

--- a/tests/app/commands/test_folder.py
+++ b/tests/app/commands/test_folder.py
@@ -5,21 +5,27 @@
 import pytest
 
 from app.commands.folder import folder_create
+from app.configs.app_config import AppConfig
 
 
-def test_folder_create_success(mocker, cli_runner):
+@pytest.mark.parametrize('zone', [AppConfig.Env.green_zone, AppConfig.Env.core_zone])
+def test_folder_create_success(mocker, cli_runner, zone):
+    project_code = 'testproject'
+    object_path = 'users/testuser/testfolder'
+
     mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
     mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
 
-    result = cli_runner.invoke(folder_create, ['testproject', 'users/testuser/testfolder'])
+    result = cli_runner.invoke(folder_create, [f'{project_code}/{object_path}', '-z', zone])
     assert result.exit_code == 0
+    assert f'Folder created: {object_path} at project: {project_code} at zone: {zone}' in result.output
 
 
 def test_folder_create_invalid_folder_path(mocker, cli_runner):
     mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
     mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
 
-    result = cli_runner.invoke(folder_create, ['testproject', 'users/testuser'])
+    result = cli_runner.invoke(folder_create, ['testproject/users/testuser'])
     assert result.exit_code == 1
     assert 'Invalid folder path' in result.output
 
@@ -30,7 +36,7 @@ def test_folder_create_invalid_folder_name(mocker, cli_runner, invalid_char):
     mocker.patch('app.services.user_authentication.token_manager.SrvTokenManager.check_valid', return_value=0)
     mocker.patch('app.services.file_manager.file_metadata.folder_client.FolderClient.create_folder', return_value={})
 
-    result = cli_runner.invoke(folder_create, ['testproject', f'users/testuser/testfolder{invalid_char}'])
+    result = cli_runner.invoke(folder_create, [f'testproject/users/testuser/testfolder{invalid_char}'])
 
     assert result.exit_code == 1
     assert 'The input folder name is not valid. Please follow the rule:' in result.output

--- a/tests/app/services/file_manager/file_metadata/test_folder_client.py
+++ b/tests/app/services/file_manager/file_metadata/test_folder_client.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2022-2024 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import pytest
+
+from app.services.file_manager.file_metadata.folder_client import FolderClient
+
+
+def test_get_root_folder_id_success(mocker):
+    project_code = 'project_code'
+    zone = 'greenroom'
+    root_folder = 'root_folder'
+    exist_parent_id = 'exist_parent_id'
+
+    search_item_mock = mocker.patch('app.services.file_manager.file_metadata.folder_client.search_item')
+    search_item_mock.return_value = {'result': {'id': exist_parent_id}}
+    folder_client = FolderClient(project_code, zone)
+
+    assert folder_client._get_root_folder_id(root_folder) == exist_parent_id
+    search_item_mock.assert_called_once_with(project_code, 0, root_folder)
+
+
+def test_get_root_folder_id_fail(mocker):
+    project_code = 'project_code'
+    zone = 'greenroom'
+    root_folder = 'root_folder'
+
+    search_item_mock = mocker.patch('app.services.file_manager.file_metadata.folder_client.search_item')
+    search_item_mock.return_value = {'result': {}}
+    folder_client = FolderClient(project_code, zone)
+
+    with pytest.raises(SystemExit):
+        folder_client._get_root_folder_id(root_folder)
+    search_item_mock.assert_called_once_with(project_code, 0, root_folder)
+
+
+def test_create_folder(mocker, httpx_mock):
+    project_code = 'project_code'
+    zone = 'greenroom'
+    folder_path = 'users/user/test'
+    exist_parent_id = 'exist_parent_id'
+
+    duplication_mock = mocker.patch(
+        'app.services.file_manager.file_metadata.folder_client.check_item_duplication',
+        return_value=['users', 'users/user'],
+    )
+    folder_client = FolderClient(project_code, zone)
+    folder_client._get_root_folder_id = mocker.Mock(return_value=exist_parent_id)
+
+    httpx_mock.add_response(
+        url=f'{folder_client.endpoint}/folders/batch',
+        json={'result': {'id': 'folder_id'}},
+    )
+
+    folder = folder_client.create_folder(folder_path)
+    assert folder == {'id': 'folder_id'}
+
+    duplication_mock.assert_called_once_with(['users/user/test'], 0, 'project_code')
+    folder_client._get_root_folder_id.assert_called_once_with('users/user')


### PR DESCRIPTION
## Summary

With new requirements of move command updates, Cli will need a new command to create a folder under project spec.

### Detail:

Adding a folder create command pilotcli folder create with following options:

```
    $pilotcli folder create <project_code>/<folder_path> -z <zone>
     - project_code: the code of project
     - folder_path: the target path of a folder to be created
     - zone: greenroom or core
````

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-5871

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add new test cases for folder create command and client
