### PR TITLE
Pilot 5835: update `file move` command to follow linux `mv` convension

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -528,26 +528,28 @@ def file_metadata_download(**kwargs):
     help=file_help.file_help_page(file_help.FileHELP.FILE_MOVE_Z),
     show_default=False,
 )
-@click.option(
-    '-y',
-    '--yes',
-    default=False,
-    required=False,
-    is_flag=True,
-    help=file_help.file_help_page(file_help.FileHELP.FILE_MOVE_Y),
-    show_default=True,
-)
+# @click.option(
+#     '-y',
+#     '--yes',
+#     default=False,
+#     required=False,
+#     is_flag=True,
+#     help=file_help.file_help_page(file_help.FileHELP.FILE_MOVE_Y),
+#     show_default=True,
+# )
 @require_valid_token()
 @doc(file_help.file_help_page(file_help.FileHELP.FILE_MOVE))
 def file_move(**kwargs):
     project_code = kwargs.get('project_code')
-    src_item_path = kwargs.get('src_item_path')
-    dest_item_path = kwargs.get('dest_item_path')
+    src_item_path = kwargs.get('src_item_path').strip('/')
+    dest_item_path = kwargs.get('dest_item_path').strip('/')
     zone = kwargs.get('zone')
-    skip_confirm = kwargs.get('yes')
 
-    if len(src_item_path.split('/')) == 1 and len(dest_item_path.split('/')) == 1:
-        raise Exception('Invalid path')
+    if len(src_item_path.split('/')) <= 2 or len(dest_item_path.split('/')) <= 1:
+        message_handler.SrvOutPutHandler.move_action_failed(
+            src_item_path, dest_item_path, 'Cannot move root/name/shared folders'
+        )
+        exit(1)
 
     # tranlate keyword to correct object path
     src_keyword, src_path = src_item_path.split('/', 1)
@@ -560,7 +562,7 @@ def file_move(**kwargs):
     dest_path = dest_type.get_prefix_by_type() + dest_path
 
     zone = get_zone(zone) if zone else AppConfig.Env.green_zone.lower()
-    file_meta_client = FileMoveClient(zone, project_code, src_path, dest_path, skip_confirm=skip_confirm)
+    file_meta_client = FileMoveClient(zone, project_code, src_path, dest_path)
     file_meta_client.move_file()
 
     message_handler.SrvOutPutHandler.move_action_success(src_item_path, dest_item_path)

--- a/app/services/file_manager/file_move/file_move_client.py
+++ b/app/services/file_manager/file_move/file_move_client.py
@@ -11,6 +11,7 @@ from httpx import HTTPStatusError
 
 import app.services.output_manager.message_handler as message_handler
 from app.configs.app_config import AppConfig
+from app.models.item import ItemType
 from app.services.clients.base_auth_client import BaseAuthClient
 from app.services.output_manager.error_handler import ECustomizedError
 from app.services.output_manager.error_handler import SrvErrorHandler
@@ -127,7 +128,29 @@ class FileMoveClient(BaseAuthClient):
             Move file.
         """
 
-        self.create_object_path_if_not_exist(self.dest_item_path)
+        # self.create_object_path_if_not_exist(self.dest_item_path)
+        # similar to linux mv command, cli will check if destination is a folder or file
+        # if file, it will raise error with duplicate
+        # if folder, it will move the file into the folder
+        # if detination is not exist, it will rename the item
+        dest_item = search_item(self.project_code, self.zone, self.dest_item_path).get('result')
+        if dest_item:
+            if dest_item.get('type') == ItemType.FILE.value:
+                item_name = dest_item.get('name')
+                message_handler.SrvOutPutHandler.move_action_failed(
+                    self.src_item_path, self.dest_item_path, f'Item {item_name} already exists'
+                )
+                exit(1)
+            else:
+                self.dest_item_path = f'{self.dest_item_path}/{self.src_item_path.split("/")[-1]}'
+        else:
+            # dest folder not exist, check if parent folder exist
+            parent_path = self.dest_item_path.rsplit('/', 1)[0]
+            parent_item = search_item(self.project_code, self.zone, parent_path).get('result')
+            if not parent_item:
+                message_handler.SrvOutPutHandler.move_action_failed(
+                    self.src_item_path, self.dest_item_path, f'Parent folder {parent_path} not exist'
+                )
 
         try:
             payload = {
@@ -144,6 +167,9 @@ class FileMoveClient(BaseAuthClient):
                 error_message = ''
                 for x in response.json().get('detail'):
                     error_message += '\n' + x.get('msg')
+            elif response.status_code == 500:
+                item_name = self.src_item_path.split('/')[-1]
+                error_message = f'Item {item_name} already exists'
             else:
                 error_message = response.json().get('error_msg')
             message_handler.SrvOutPutHandler.move_action_failed(self.src_item_path, self.dest_item_path, error_message)

--- a/app/services/file_manager/file_move/file_move_client.py
+++ b/app/services/file_manager/file_move/file_move_client.py
@@ -138,7 +138,7 @@ class FileMoveClient(BaseAuthClient):
             if dest_item.get('type') == ItemType.FILE.value:
                 item_name = dest_item.get('name')
                 message_handler.SrvOutPutHandler.move_action_failed(
-                    self.src_item_path, self.dest_item_path, f'Item {item_name} already exists'
+                    self.src_item_path, f'{self.dest_item_path}/{item_name}', f'Item {item_name} already exists'
                 )
                 exit(1)
             else:
@@ -151,6 +151,7 @@ class FileMoveClient(BaseAuthClient):
                 message_handler.SrvOutPutHandler.move_action_failed(
                     self.src_item_path, self.dest_item_path, f'Parent folder {parent_path} not exist'
                 )
+                exit(1)
 
         try:
             payload = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.2.0"
+version = "3.3.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -374,10 +374,40 @@ def test_file_move_success(mocker, cli_runner):
         return_value=None,
     )
 
-    src_path = 'src_item_path/test'
-    dest_path = 'dest_item_path/test'
+    src_path = 'src_item_path/test/file.txt'
+    dest_path = 'dest_item_path/test/file1.txt'
     result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
 
     outputs = result.output.split('\n')
     assert outputs[0] == f'Successfully moved {src_path} to {dest_path}'
     file_move_mock.assert_called_once()
+
+
+@pytest.mark.parametrize('src_path', ['src_item_path', 'src_item_path/test'])
+def test_file_move_failed_with_invalid_src(mocker, cli_runner, src_path):
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+
+    dest_path = 'dest_item_path/test/file1.txt'
+    result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
+    assert result.exit_code == 1
+
+    outputs = result.output.split('\n')
+    assert outputs[0] == f'Failed to move {src_path} to {dest_path}: Cannot move root/name/shared folders'
+
+
+@pytest.mark.parametrize('dest_path', ['dest_item_path'])
+def test_file_move_failed_with_invalid_dest(mocker, cli_runner, dest_path):
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+
+    src_path = 'src_item_path/test/file.txt'
+    result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
+    assert result.exit_code == 1
+
+    outputs = result.output.split('\n')
+    assert outputs[0] == f'Failed to move {src_path} to {dest_path}: Cannot move root/name/shared folders'

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -402,9 +402,10 @@ def test_file_move_success(mocker, cli_runner):
         return_value=None,
     )
 
-    src_path = 'src_item_path/test/file.txt'
-    dest_path = 'dest_item_path/test/file1.txt'
-    result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
+    project_code = 'test_project'
+    src_path = f'{project_code}/src_item_path/test/file.txt'
+    dest_path = f'{project_code}/dest_item_path/test/file1.txt'
+    result = cli_runner.invoke(file_move, [src_path, dest_path])
 
     outputs = result.output.split('\n')
     assert outputs[0] == f'Successfully moved {src_path} to {dest_path}'
@@ -418,8 +419,10 @@ def test_file_move_failed_with_invalid_src(mocker, cli_runner, src_path):
         return_value=decoded_token(),
     )
 
-    dest_path = 'dest_item_path/test/file1.txt'
-    result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
+    project_code = 'test_project'
+    src_path = f'{project_code}/{src_path}'
+    dest_path = f'{project_code}/dest_item_path/test/file1.txt'
+    result = cli_runner.invoke(file_move, [src_path, dest_path])
     assert result.exit_code == 1
 
     outputs = result.output.split('\n')
@@ -433,9 +436,27 @@ def test_file_move_failed_with_invalid_dest(mocker, cli_runner, dest_path):
         return_value=decoded_token(),
     )
 
-    src_path = 'src_item_path/test/file.txt'
-    result = cli_runner.invoke(file_move, ['test_project', src_path, dest_path])
+    project_code = 'test_project'
+    src_path = f'{project_code}/src_item_path/test/file.txt'
+    dest_path = f'{project_code}/{dest_path}'
+    result = cli_runner.invoke(file_move, [src_path, dest_path])
     assert result.exit_code == 1
 
     outputs = result.output.split('\n')
     assert outputs[0] == f'Failed to move {src_path} to {dest_path}: Cannot move root/name/shared folders'
+
+
+def test_file_move_failed_with_mismatched_project_code(mocker, cli_runner):
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+
+    project_code = 'test_project'
+    src_path = f'{project_code}/src_item_path/test/file.txt'
+    dest_path = 'wrong_project/dest_item_path/test/file1.txt'
+    result = cli_runner.invoke(file_move, [src_path, dest_path])
+    assert result.exit_code == 1
+
+    outputs = result.output.split('\n')
+    assert outputs[0] == f'Failed to move {src_path} to {dest_path}: Cannot move files between different projects'

--- a/tests/app/services/file_manager/file_move/test_file_move_client.py
+++ b/tests/app/services/file_manager/file_move/test_file_move_client.py
@@ -5,6 +5,7 @@
 import pytest
 
 from app.configs.app_config import AppConfig
+from app.models.item import ItemType
 from app.services.file_manager.file_move.file_move_client import FileMoveClient
 from tests.conftest import decoded_token
 
@@ -21,7 +22,7 @@ def test_file_move_success(mocker, httpx_mock, root_folder):
 
     mocker.patch(
         'app.services.file_manager.file_move.file_move_client.search_item',
-        return_value={'result': {'id': 'test_id', 'name': 'test_name'}},
+        return_value={'result': {'id': 'test_id', 'name': 'test_name', 'type': ItemType.FOLDER.value}},
     )
 
     httpx_mock.add_response(
@@ -101,4 +102,64 @@ def test_file_move_error_with_wrong_input_422(mocker, httpx_mock, capfd, root_fo
         assert (
             out
             == f'Failed to move {root_folder}/src_item_path/item to {root_folder}/dest_item_path/item: \nerror_msg\n'
+        )
+
+
+@pytest.mark.parametrize('root_folder', ['users', 'shared'])
+def test_file_move_fails_if_destination_is_file(mocker, httpx_mock, capfd, root_folder):
+    project_code = 'test_code'
+    root_folder = 'users'
+    item_name = 'test_name'
+
+    project_code = 'test_code'
+
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+
+    mocker.patch(
+        'app.services.file_manager.file_move.file_move_client.search_item',
+        return_value={'result': {'id': 'test_id', 'name': item_name, 'type': ItemType.FILE.value}},
+    )
+
+    file_move_client = FileMoveClient(
+        'zone', project_code, f'{root_folder}/src_item_path/item', f'{root_folder}/dest_item_path'
+    )
+    try:
+        file_move_client.move_file()
+    except SystemExit:
+        out, _ = capfd.readouterr()
+        assert (
+            out == f'Failed to move {root_folder}/src_item_path/item to {root_folder}/dest_item_path/'
+            f'{item_name}: Item test_name already exists\n'
+        )
+
+
+@pytest.mark.parametrize('root_folder', ['users', 'shared'])
+def test_file_move_failed_when_parent_not_exist(mocker, httpx_mock, capfd, root_folder):
+    project_code = 'test_code'
+    root_folder = 'users'
+    item_name = 'new_name'
+
+    project_code = 'test_code'
+
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+
+    mocker.patch('app.services.file_manager.file_move.file_move_client.search_item', return_value={'result': None})
+
+    file_move_client = FileMoveClient(
+        'zone', project_code, f'{root_folder}/src_item_path/item', f'{root_folder}/not_exist/{item_name}'
+    )
+
+    try:
+        file_move_client.move_file()
+    except SystemExit:
+        out, _ = capfd.readouterr()
+        assert (
+            out == f'Failed to move {root_folder}/src_item_path/item to {root_folder}/not_exist'
+            f'/{item_name}: Parent folder {root_folder}/not_exist not exist\n'
         )

--- a/tests/app/services/file_manager/file_move/test_file_move_client.py
+++ b/tests/app/services/file_manager/file_move/test_file_move_client.py
@@ -20,8 +20,8 @@ def test_file_move_success(mocker, httpx_mock, root_folder):
     )
 
     mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.FileMoveClient.create_object_path_if_not_exist',
-        return_value=[],
+        'app.services.file_manager.file_move.file_move_client.search_item',
+        return_value={'result': {'id': 'test_id', 'name': 'test_name'}},
     )
 
     httpx_mock.add_response(
@@ -31,7 +31,7 @@ def test_file_move_success(mocker, httpx_mock, root_folder):
     )
 
     file_move_client = FileMoveClient(
-        'zone', project_code, f'{root_folder}/src_item_path', f'{root_folder}/dest_item_path'
+        'zone', project_code, f'{root_folder}/src_item_path/item', f'{root_folder}/dest_item_path'
     )
     res = file_move_client.move_file()
     assert res == item_info
@@ -47,8 +47,8 @@ def test_file_move_error_with_permission_denied_403(mocker, httpx_mock, capfd, r
     )
 
     mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.FileMoveClient.create_object_path_if_not_exist',
-        return_value=[],
+        'app.services.file_manager.file_move.file_move_client.search_item',
+        return_value={'result': {'id': 'test_id', 'name': 'test_name'}},
     )
 
     httpx_mock.add_response(
@@ -59,13 +59,15 @@ def test_file_move_error_with_permission_denied_403(mocker, httpx_mock, capfd, r
     )
 
     file_move_client = FileMoveClient(
-        'zone', project_code, f'{root_folder}/src_item_path', f'{root_folder}/dest_item_path'
+        'zone', project_code, f'{root_folder}/src_item_path/item', f'{root_folder}/dest_item_path'
     )
     try:
         file_move_client.move_file()
     except SystemExit:
         out, _ = capfd.readouterr()
-        assert out == f'Failed to move {root_folder}/src_item_path to {root_folder}/dest_item_path: error_msg\n'
+        assert (
+            out == f'Failed to move {root_folder}/src_item_path/item to {root_folder}/dest_item_path/item: error_msg\n'
+        )
 
 
 @pytest.mark.parametrize('root_folder', ['users', 'shared'])
@@ -78,8 +80,8 @@ def test_file_move_error_with_wrong_input_422(mocker, httpx_mock, capfd, root_fo
     )
 
     mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.FileMoveClient.create_object_path_if_not_exist',
-        return_value=[],
+        'app.services.file_manager.file_move.file_move_client.search_item',
+        return_value={'result': {'id': 'test_id', 'name': 'test_name'}},
     )
 
     httpx_mock.add_response(
@@ -90,99 +92,13 @@ def test_file_move_error_with_wrong_input_422(mocker, httpx_mock, capfd, root_fo
     )
 
     file_move_client = FileMoveClient(
-        'zone', project_code, f'{root_folder}/src_item_path', f'{root_folder}/dest_item_path'
+        'zone', project_code, f'{root_folder}/src_item_path/item', f'{root_folder}/dest_item_path'
     )
     try:
         file_move_client.move_file()
     except SystemExit:
         out, _ = capfd.readouterr()
-        assert out == f'Failed to move {root_folder}/src_item_path to {root_folder}/dest_item_path: \nerror_msg\n'
-
-
-@pytest.mark.parametrize('skip_confirmation', [True, False])
-@pytest.mark.parametrize('root_folder', ['users', 'shared'])
-def test_move_file_dest_parent_not_exist_success(mocker, httpx_mock, skip_confirmation, root_folder):
-    project_code = 'test_code'
-    item_info = {'result': {'id': 'test_id', 'name': 'test_name'}}
-
-    mocker.patch(
-        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
-        return_value=decoded_token(),
-    )
-
-    # mock duplicated item
-    mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.check_item_duplication',
-        return_value=[],
-    )
-    mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.search_item',
-        return_value={'result': {'id': 'test_id', 'name': 'test_name'}},
-    )
-    click_mocker = mocker.patch('app.services.file_manager.file_move.file_move_client.click.confirm', return_value=None)
-    httpx_mock.add_response(
-        url=AppConfig.Connections.url_bff + '/v1/folders/batch',
-        method='POST',
-        json={'result': []},
-    )
-
-    httpx_mock.add_response(
-        url=AppConfig.Connections.url_bff + f'/v1/{project_code}/files',
-        method='PATCH',
-        json={'result': item_info},
-    )
-
-    file_move_client = FileMoveClient(
-        'zone',
-        project_code,
-        f'{root_folder}/src_item_path',
-        f'{root_folder}/dest_item_path/test_folder/test_file',
-        skip_confirm=skip_confirmation,
-    )
-    res = file_move_client.move_file()
-    assert res == item_info
-    if not skip_confirmation:
-        click_mocker.assert_called_once()
-    else:
-        click_mocker.assert_not_called()
-
-
-@pytest.mark.parametrize('skip_confirmation', [True, False])
-@pytest.mark.parametrize('root_folder', ['users', 'shared'])
-def test_move_file_dest_parent_lv2_not_exist_fail(mocker, httpx_mock, capfd, skip_confirmation, root_folder):
-    project_code = 'test_code'
-
-    mocker.patch(
-        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
-        return_value=decoded_token(),
-    )
-
-    # mock duplicated item
-    mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.check_item_duplication',
-        return_value=[],
-    )
-    click_mocker = mocker.patch('app.services.file_manager.file_move.file_move_client.click.confirm', return_value=None)
-
-    mocker.patch(
-        'app.services.file_manager.file_move.file_move_client.search_item',
-        return_value={'result': {}},
-    )
-
-    file_move_client = FileMoveClient(
-        'zone',
-        project_code,
-        f'{root_folder}/src_item_path',
-        f'{root_folder}/not_exist/test_folder/test_file',
-        skip_confirm=skip_confirmation,
-    )
-    try:
-        file_move_client.move_file()
-    except SystemExit:
-        out, _ = capfd.readouterr()
-        assert out == f'Parent folder: {root_folder}/not_exist not exist\n'
-
-    if not skip_confirmation:
-        click_mocker.assert_called_once()
-    else:
-        click_mocker.assert_not_called()
+        assert (
+            out
+            == f'Failed to move {root_folder}/src_item_path/item to {root_folder}/dest_item_path/item: \nerror_msg\n'
+        )


### PR DESCRIPTION
## Summary

 - moving file into destination path. It will raise error when duplication occurs in destination folder.
```
file move ${project_code}/{src_file_path}/${file_name} ${project_code}/${dest_file_path}/ -z greenroom
file move ${project_code}/{src_file_path}/${file_name} ${project_code}/${dest_file_path} -z greenroom
```

 - renaming file if there is no such item exist in destination path. It will raise error when duplication occurs in destination folder.
```
file move ${project_code}/${src_file_path}/${file_name} ${project_code}/${dest_file_path}/${file_name} -z greenroom
```

 - folder creation logic will be removed since it will make confusion when move or rename an item.
 - remove project code argument. now `src_path` and `dest_path` will be formatted `<project_code>/<path>`.

## JIRA Issues

Pilot 5835

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

update testcase with new inputs
