### PR TITLE
Pilot 6007: Add `Content-Md5` header in presigned url upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.4.0"
+version = "3.5.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/services/file_manager/file_upload/test_upload_client.py
+++ b/tests/app/services/file_manager/file_upload/test_upload_client.py
@@ -81,6 +81,19 @@ def test_chunk_upload(httpx_mock, mocker):
     assert res.status_code == 200
 
 
+def test_chunk_upload_failed_with_401(httpx_mock):
+    upload_client = UploadClient('project_code', 'parent_folder_id')
+
+    test_presigned_url = 'http://test.url/presigned'
+    url = re.compile('^' + AppConfig.Connections.url_upload_greenroom + '/v1/files/chunks/presigned.*$')
+    httpx_mock.add_response(method='GET', url=url, json={'result': test_presigned_url})
+    httpx_mock.add_response(method='PUT', url=test_presigned_url, json={'result': ''}, status_code=401)
+
+    test_obj = FileObject('test', 'test', 'test', 'test', 'test')
+    with pytest.raises(SystemExit):
+        upload_client.upload_chunk(test_obj, 0, b'1', 'test_etag', 10)
+
+
 def test_token_refresh_auto(mocker):
     AppConfig.Env.token_refresh_interval = 1
 

--- a/tests/app/services/file_manager/file_upload/test_upload_client.py
+++ b/tests/app/services/file_manager/file_upload/test_upload_client.py
@@ -81,13 +81,14 @@ def test_chunk_upload(httpx_mock, mocker):
     assert res.status_code == 200
 
 
-def test_chunk_upload_failed_with_401(httpx_mock):
+def test_chunk_upload_failed_with_401(httpx_mock, mocker):
     upload_client = UploadClient('project_code', 'parent_folder_id')
 
     test_presigned_url = 'http://test.url/presigned'
     url = re.compile('^' + AppConfig.Connections.url_upload_greenroom + '/v1/files/chunks/presigned.*$')
     httpx_mock.add_response(method='GET', url=url, json={'result': test_presigned_url})
     httpx_mock.add_response(method='PUT', url=test_presigned_url, json={'result': ''}, status_code=401)
+    mocker.patch('app.services.file_manager.file_upload.models.FileObject.generate_meta', return_value=(1, 1))
 
     test_obj = FileObject('test', 'test', 'test', 'test', 'test')
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary

In order to let azure blob storage check block integrity, we need to add one more header Content-MD5 when sending chunks through presigned url.
 
## Detail:

 - adding Content-MD5 when uploading chunks through presigned url. Format of Content-MD5 should be base64 encoded, see python code:
```
base64.b64encode(hashlib.md5(chunk).digest()).decode('utf-8')
```
 - update the same header Content-MD5 for /v1/files/chunks/presigned endpoint to base64 encoded. Currently it is hex based and only used by pilot backend for resumable uploading.
 - update test cases

## JIRA Issues

Pilot 6007

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add new test cases when presigned upload failed with 401
