### PR TITLE
Patch20240913: fixup cli use chunk_size of last chunk instead of actual size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.5.1"
+version = "3.5.2"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

Fixup cli uses chunk_size of last chunk instead of actual size. It will fail integrity check in upload service

## JIRA Issues

none

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add new test cases for stream upload
