### PR TITLE
Pilot 6155: add logic to display `TRASHED` item in `file list` command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,15 +55,15 @@ repos:
           '--max-line-length=120',
         ]
 
-  - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
-    hooks:
-      - id: docformatter
-        args: [
-          '--wrap-summaries=120',
-          '--wrap-descriptions=120',
-          '--in-place',
-        ]
+  # - repo: https://github.com/myint/docformatter
+  #   rev: v1.5.0
+  #   hooks:
+  #     - id: docformatter
+  #       args: [
+  #         '--wrap-summaries=120',
+  #         '--wrap-descriptions=120',
+  #         '--in-place',
+  #       ]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.4.2

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -352,14 +352,6 @@ def file_export_manifest(project_code, attribute_name):
     help='whether run in detached mode',
     show_default=True,
 )
-# @click.option(
-#     '--trashed',
-#     default=False,
-#     required=False,
-#     is_flag=True,
-#     help='whether list trashed files',
-#     show_default=True,
-# )
 @require_valid_token()
 @doc(file_help.file_help_page(file_help.FileHELP.FILE_LIST))
 def file_list(paths, zone, page, page_size, detached):

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -352,6 +352,14 @@ def file_export_manifest(project_code, attribute_name):
     help='whether run in detached mode',
     show_default=True,
 )
+# @click.option(
+#     '--trashed',
+#     default=False,
+#     required=False,
+#     is_flag=True,
+#     help='whether list trashed files',
+#     show_default=True,
+# )
 @require_valid_token()
 @doc(file_help.file_help_page(file_help.FileHELP.FILE_LIST))
 def file_list(paths, zone, page, page_size, detached):

--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -31,6 +31,11 @@ class AppConfig:
 
         github_url = 'PilotDataPlatform/cli'
 
+        zone_int2string = {
+            0: green_zone,
+            1: core_zone,
+        }
+
     class Connections:
         url_harbor = ConfigClass.url_harbor
         url_authn = ConfigClass.url_authn

--- a/app/models/item.py
+++ b/app/models/item.py
@@ -13,6 +13,7 @@ class ItemType(str, Enum):
     NAMEFOLDER = 'name_folder'
     SHAREDFOLDER = 'project_folder'
     ROOTFOLDER = 'root_folder'
+    TRASH = 'trash'
 
     @classmethod
     def get_type_from_keyword(self, keyword: str):
@@ -25,6 +26,7 @@ class ItemType(str, Enum):
         alternative_mapping = {
             'shared': self.SHAREDFOLDER,
             'users': self.NAMEFOLDER,
+            'trash': self.TRASH,
         }
 
         return alternative_mapping.get(keyword, self.FOLDER)
@@ -36,6 +38,7 @@ class ItemType(str, Enum):
             self.NAMEFOLDER: 'users/',
             self.SHAREDFOLDER: 'shared/',
             self.ROOTFOLDER: '',
+            self.TRASH: '',
         }
 
         return prefix.get(self.value, '')

--- a/app/services/file_manager/file_list.py
+++ b/app/services/file_manager/file_list.py
@@ -25,10 +25,6 @@ class SrvFileList(BaseAuthClient, metaclass=MetaService):
         super().__init__(AppConfig.Connections.url_bff)
 
         self.endpoint = AppConfig.Connections.url_bff + '/v1'
-        self.zone_map = {
-            0: AppConfig.Env.green_zone,
-            1: AppConfig.Env.core_zone,
-        }
 
     @require_valid_token()
     def list_files(self, paths: str, zone: str, page: int, page_size: int) -> Tuple[str, int]:
@@ -77,7 +73,7 @@ class SrvFileList(BaseAuthClient, metaclass=MetaService):
 
             # formating zone info for trashed items
             if f.get('status') == ItemStatus.TRASHED:
-                zone = self.zone_map.get(f.get('zone'))
+                zone = AppConfig.Env.zone_int2string.get(f.get('zone'))
                 f['name'] = f'{f.get("name")}({zone})'
 
             if item_type == ItemType.FILE:

--- a/app/services/file_manager/file_list.py
+++ b/app/services/file_manager/file_list.py
@@ -6,9 +6,11 @@ from typing import Tuple
 
 import click
 import questionary
+from httpx import HTTPStatusError
 
 import app.services.logger_services.log_functions as logger
 from app.configs.app_config import AppConfig
+from app.models.item import ItemStatus
 from app.models.item import ItemType
 from app.models.service_meta_class import MetaService
 from app.services.clients.base_auth_client import BaseAuthClient
@@ -23,35 +25,48 @@ class SrvFileList(BaseAuthClient, metaclass=MetaService):
         super().__init__(AppConfig.Connections.url_bff)
 
         self.endpoint = AppConfig.Connections.url_bff + '/v1'
+        self.zone_map = {
+            0: AppConfig.Env.green_zone,
+            1: AppConfig.Env.core_zone,
+        }
 
     @require_valid_token()
-    def list_files(self, paths, zone, page, page_size) -> Tuple[str, int]:
+    def list_files(self, paths: str, zone: str, page: int, page_size: int) -> Tuple[str, int]:
         # path is formatted as <project_code>/<root_folder>/<folder1>
         # split the path in to project_code, root_folder, and folder1
         project_path = paths.strip('/').split('/')
         project_code, source_type = project_path[0], 'project'
         folder_rel_path = '/'.join(project_path[1:])
+        root_folder = ItemType.ROOTFOLDER
         if len(project_path) > 1:
             root_folder = ItemType.get_type_from_keyword(project_path[1])
             folder_rel_path = folder_rel_path.replace(project_path[1], root_folder.get_prefix_by_type()[:-1], 1)
+            folder_rel_path = folder_rel_path.lstrip('/')
 
         # now query the backend to get the file list
+        status = ItemStatus.TRASHED if root_folder == ItemType.TRASH else ItemStatus.ACTIVE
+        zone = '' if root_folder == ItemType.TRASH else zone
         params = {
             'project_code': project_code,
-            'folder': folder_rel_path,
             'source_type': source_type,
+            'folder': folder_rel_path,
             'zone': zone,
             'page': page,
             'page_size': page_size,
+            'status': str(status),
         }
-        response = self._get(f'{project_code}/files/query', params=params)
-        res_json = response.json()
-        if res_json.get('code') == 403 and res_json.get('error_msg') != 'Folder not exist':
-            SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, True)
-        elif res_json.get('error_msg') == 'Folder not exist':
-            SrvErrorHandler.customized_handle(ECustomizedError.INVALID_FOLDER, True)
-        res = res_json.get('result')
+        try:
+            response = self._get(f'{project_code}/files/query', params=params)
+            res_json = response.json()
+        except HTTPStatusError as e:
+            response = e.response
+            res_json = response.json()
+            if response.status_code == 403 and res_json.get('error_msg') != 'Folder not exist':
+                SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, True)
+            elif res_json.get('error_msg') == 'Folder not exist':
+                SrvErrorHandler.customized_handle(ECustomizedError.INVALID_FOLDER, True)
 
+        res = res_json.get('result')
         # then format the console output
         files, folders = '', ''
         for f in res:
@@ -59,6 +74,11 @@ class SrvFileList(BaseAuthClient, metaclass=MetaService):
             # if there is space within the nane add double quotation to aviod confusion
             if ' ' in f.get('name'):
                 f['name'] = f'"{f.get("name")}"'
+
+            # formating zone info for trashed items
+            if f.get('status') == ItemStatus.TRASHED:
+                zone = self.zone_map.get(f.get('zone'))
+                f['name'] = f'{f.get("name")}({zone})'
 
             if item_type == ItemType.FILE:
                 files = files + f.get('name') + ' ...'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.6.0"
+version = "3.7.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

in order to delete items in trashbin, a new logic will need to be add into `file list` command for listing items in trash bin. The example will be:

```
$ poetry run python app/pilotcli.py file list tp01/trash
test20240911(greenroom)  test20240607(greenroom)  chrome_100_percent.pak(core)
```

## JIRA Issues

Pilot 6155

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add new test for listing items in trashbin
