### PR TITLE
PILOT-6155: remove bracket in trash list instead using zone to display

### DIFF
--- a/app/services/file_manager/file_list.py
+++ b/app/services/file_manager/file_list.py
@@ -45,7 +45,6 @@ class SrvFileList(BaseAuthClient, metaclass=MetaService):
 
         # now query the backend to get the file list
         status = ItemStatus.TRASHED if root_folder == ItemType.TRASH else ItemStatus.ACTIVE
-        zone = '' if root_folder == ItemType.TRASH else zone
         params = {
             'project_code': project_code,
             'source_type': source_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.8.0"
+version = "3.8.1"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -188,7 +188,11 @@ def test_file_list_with_pagination_with_folder_success(httpx_mock, mocker, cli_r
     assert outputs[1] == ''.join([f'f{i}  ' for i in range(page_size)]) + ' '
 
 
-def test_file_list_in_trashbin(httpx_mock, mocker, cli_runner):
+@pytest.mark.parametrize(
+    'zone',
+    ['greenroom', 'core'],
+)
+def test_file_list_in_trashbin(httpx_mock, mocker, cli_runner, zone):
     mocker.patch(
         'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
         return_value=decoded_token(),
@@ -197,7 +201,7 @@ def test_file_list_in_trashbin(httpx_mock, mocker, cli_runner):
     httpx_mock.add_response(
         method='GET',
         url='http://bff_cli/v1/testproject/files/query?project_code=testproject&folder=&'
-        'source_type=project&zone=&page=0&page_size=10&status=TRASHED',
+        f'source_type=project&zone={zone}&page=0&page_size=10&status=TRASHED',
         json={
             'code': 200,
             'error_msg': '',
@@ -210,7 +214,7 @@ def test_file_list_in_trashbin(httpx_mock, mocker, cli_runner):
     )
     # mocker.patch.object(questionary, 'select')
     # questionary.select.return_value.ask.return_value = 'exit'
-    result = cli_runner.invoke(file_list, ['testproject/trash'])
+    result = cli_runner.invoke(file_list, ['testproject/trash', '-z', zone])
     assert result.exit_code == 0
     outputs = result.output.split('\n')
     assert outputs[0] == 'test.txt(greenroom)  test1.txt(core)   '


### PR DESCRIPTION
## Summary

remove bracket suffix when list file in trash bin. Instead use `--zone` to switch between different zones. By default, `zone` is set to `greenroom`

## JIRA Issues

PILOT-6155

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

update trash listing related test cases
