### PR TITLE
Pilot 6468: overwrite click help function to disable wrap around

### DIFF
--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -374,7 +374,7 @@ def file_list(paths, zone, page, page_size, detached):
         srv_list.list_files_with_pagination(paths, zone, page, page_size)
 
 
-@click.command(name='download')
+@click.command(name='download', context_settings={'max_content_width': 120})
 @click.argument('paths', type=click.STRING, nargs=-1)
 @click.argument('output_path', type=click.Path(exists=True), nargs=1)
 @click.option(

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -374,7 +374,7 @@ def file_list(paths, zone, page, page_size, detached):
         srv_list.list_files_with_pagination(paths, zone, page, page_size)
 
 
-@click.command(name='download', context_settings={'max_content_width': 120})
+@click.command(name='download')
 @click.argument('paths', type=click.STRING, nargs=-1)
 @click.argument('output_path', type=click.Path(exists=True), nargs=1)
 @click.option(

--- a/app/pilotcli.py
+++ b/app/pilotcli.py
@@ -6,6 +6,7 @@ from multiprocessing import freeze_support
 
 import click
 import pkg_resources
+from click.formatting import HelpFormatter
 from packaging.version import Version
 
 import app.services.output_manager.error_handler as error_handler
@@ -15,6 +16,38 @@ from app.commands.entry_point import entry_point
 from app.services.output_manager.help_page import get_cli_help_message
 from app.utils.aggregated import doc
 from app.utils.aggregated import get_latest_cli_version
+
+
+class CustomHelpFormatter(HelpFormatter):
+    def __init__(self, *args, **kwargs):
+        # Set a desired width to avoid wrapping of the help text
+        kwargs['width'] = 200
+        super().__init__(*args, **kwargs)
+
+    def write_dl(self, rows, col_max=80, col_spacing=2):
+        if rows:
+            # get max width of command
+            widths = max([len(row[0]) for row in rows])
+            for command, help_doc in rows:
+                self.write(f'{command:<{widths}}  ')
+                if help_doc:
+                    while len(help_doc) > col_max:
+                        # find the last space within the col_max
+                        last_space = help_doc[:col_max].rfind(' ')
+                        if last_space == -1:
+                            last_space = col_max
+                        last_space += 1
+
+                        self.write(f'{help_doc[:last_space]}\n')
+                        # filling the new line with indent spacing
+                        self.write(' ' * (widths + col_spacing))
+                        help_doc = help_doc[last_space:]
+
+                    self.write(f'{help_doc}')
+                    self.write('\n')
+
+
+click.Context.formatter_class = CustomHelpFormatter
 
 
 class ComplexCLI(click.MultiCommand):

--- a/app/resources/custom_help.py
+++ b/app/resources/custom_help.py
@@ -34,7 +34,7 @@ class HelpPage:
             'FILE_ATTRIBUTE_LIST': 'List attribute templates of a given Project.',
             'FILE_ATTRIBUTE_EXPORT': 'Export attribute template from a given Project.',
             'FILE_LIST': 'List files and folders inside a given project/folder.',
-            'FILE_SYNC': 'Download files/folders from a given Project folder file in core zone.',
+            'FILE_SYNC': 'Download files/folders from a given Project/folder/file in core zone.',
             'FILE_UPLOAD': 'Upload files/folders to a given Project path (project/users/user/path).',
             'FILE_RESUME': 'Resume the upload process with a resumable upload log.',
             'FILE_Z': 'Target Zone (i.e., core/greenroom).',

--- a/app/resources/custom_help.py
+++ b/app/resources/custom_help.py
@@ -33,9 +33,9 @@ class HelpPage:
         'file': {
             'FILE_ATTRIBUTE_LIST': 'List attribute templates of a given Project.',
             'FILE_ATTRIBUTE_EXPORT': 'Export attribute template from a given Project.',
-            'FILE_LIST': 'List files and folders inside a given Project/folder.',
-            'FILE_SYNC': 'Download files/folders from a given Project/folder/file in core zone.',
-            'FILE_UPLOAD': 'Upload files/folders to a given Project path (eg. <project>/users/<user>/<path>).',
+            'FILE_LIST': 'List files and folders inside a given project/folder.',
+            'FILE_SYNC': 'Download files/folders from a given Project folder file in core zone.',
+            'FILE_UPLOAD': 'Upload files/folders to a given Project path (project/users/user/path).',
             'FILE_RESUME': 'Resume the upload process with a resumable upload log.',
             'FILE_Z': 'Target Zone (i.e., core/greenroom).',
             'FILE_ATTRIBUTE_P': 'Project Code',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.9.0"
+version = "3.10.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

Overwrite the help function in pyclick, so that cli can display help menu with 80 char per line. If length of document is greater than 80 char, it will jump to a new line.

```
Commands:
attribute-export  Export attribute template from a given Project.
attribute-list    List attribute templates of a given Project.
download          Download files/folders from a given Project folder file in core zone.
list              List files and folders inside a given project/folder.
metadata          Download metadata file of a given file in target zone.
move              Move/Rename files/folders to a given Project path.
resume            Resume the upload process with a resumable upload log.
trash             Move files/folders to trash bin.
upload            Upload files/folders to a given Project path (project/users/user/path).
```

## JIRA Issues

Pilot 6468

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

no test cases updated
