### PR TITLE
Patch20241209: macos-12 is deprecated now use macos-latest for building binary

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -98,7 +98,7 @@ jobs:
   push-binary-macos:
     needs: [ push-binary-linux ]
     if: ${{ needs.extract-branch-name.outputs.branch == 'main' || needs.extract-branch-name.outputs.branch == 'develop'}}
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Fixup pipeline where macos-12 is deprecated now use macos-latest for building binary.

## JIRA Issues

None

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

no updates
