### PR TITLE
PILOT-6741: Add CI workflow for building and pushing CLI docker image

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -1,0 +1,61 @@
+name: Build and Publish Docker Image
+
+on:
+ workflow_dispatch:
+    inputs:
+      os:
+        description: 'Operating system of CLI binary'
+        required: true
+        type: string
+      version:
+        description: 'Version of CLI tool'
+        required: true
+        type: string
+
+jobs:
+  build_and_publish_pilotcli_image:
+    uses: PilotDataPlatform/shared-ci-tools/.github/workflows/reusable_docker_build.yml@main
+    with:
+      docker_registry: 'indocpilot.azurecr.io'
+      image_name: 'pilotcli'
+      image_tag: "${{ github.event.inputs.os }}-${{ github.event.inputs.version }}"
+      dockerfile_path: '.'
+    secrets:
+      docker_registry_username: ${{ secrets.ACR_CLIENT }}
+      docker_registry_password: ${{ secrets.ACR_SECRET }}
+
+  run-trivy:
+    needs: [ build_and_publish_pilotcli_image ]
+    name: Run Trivy vulnerability scanner and publish scan results
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: '${{ needs.build_and_publish_pilotcli_image.steps.meta.outputs.tags }}'
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          hide-progress: true
+          trivyignores: .github/.trivyignore
+          output: scan-results.txt
+        env:
+          TRIVY_IGNORE_STATUS: 'will_not_fix'
+          TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db:2'
+
+      - name: Publish Trivy Scan Results to Summary
+        if: always()
+        run: |
+          if [[ -s scan-results.txt ]]; then
+            {
+              echo "### Trivy Scan Results"
+              echo "Please refer to https://indocconsortium.atlassian.net/wiki/spaces/PILOT/pages/3917316126/Trivy+reports+triage to find out the next steps to fix the vulnerabilities"
+              echo "<details><summary>Click to expand</summary>"
+              echo ""
+              echo '```workflow-manager'
+              cat scan-results.txt
+              echo '```'
+              echo "</details>"
+            } >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -89,6 +89,7 @@ jobs:
             tags: ${{ steps.meta.outputs.tags }}
             # build on feature branches, push only on main branch
             push: false
+            load: true
             build-args: |
               CLI_VERSION=${{ github.event.inputs.release }}
               CLI_OS=${{ github.event.inputs.os }}

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -7,7 +7,11 @@ on:
       os:
         description: 'Operating system of CLI binary'
         required: true
-        type: string
+        type: choice
+        options:
+          - linux
+          - macos
+          - cloud
       release:
         description: 'Release version of CLI tool'
         required: true
@@ -87,6 +91,7 @@ jobs:
             push: false
             build-args: |
               CLI_VERSION=${{ github.event.inputs.release }}
+              CLI_OS=${{ github.event.inputs.os }}
         - name: Run Trivy vulnerability scanner
           uses: aquasecurity/trivy-action@0.24.0
           with:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -1,7 +1,6 @@
 name: Build and Publish Docker Image
 
 on:
- pull_request:
  workflow_dispatch:
     inputs:
       os:
@@ -21,9 +20,6 @@ on:
         type: string
         required: false
         default: "indocpilot.azurecr.io"
- push:
-   branches:
-     - 'PILOT-6741'
 
 jobs:
   get-version:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -11,10 +11,6 @@ on:
         description: 'Version of CLI tool'
         required: true
         type: string
- pull_request:
-    branches:
-      - main
-      - develop
 
 jobs:
   build_and_publish_pilotcli_image:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -11,9 +11,6 @@ on:
         description: 'Version of CLI tool'
         required: true
         type: string
- pull_request:
-   branches:
-     - PILOT-6741
 
 jobs:
   build_and_publish_pilotcli_image:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -9,7 +9,6 @@ on:
         type: choice
         options:
           - linux
-          - macos
           - cloud
       release:
         description: 'Release version of CLI tool'

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -16,7 +16,6 @@ on:
         type: string
         required: false
         default: "indocpilot.azurecr.io"
- pull_request:
 
 jobs:
   get-version:
@@ -50,8 +49,8 @@ jobs:
           uses: docker/login-action@v2
           with:
             registry: ${{ inputs.docker_registry }}
-            username: ${{ secrets.docker_registry_username }}
-            password: ${{ secrets.docker_registry_password }}
+            username: ${{ secrets.ACR_CLIENT }}
+            password: ${{ secrets.ACR_SECRET }}
         - name: Docker metadata
           id: meta
           uses: docker/metadata-action@v4

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -82,7 +82,6 @@ jobs:
             context: .
             # Note: tags has to be all lower-case
             tags: ${{ steps.meta.outputs.tags }}
-            # build on feature branches, push only on main branch
             push: true
             load: true
             build-args: |

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -16,6 +16,9 @@ on:
         type: string
         required: false
         default: "indocpilot.azurecr.io"
+ push:
+   branches:
+     - 'PILOT-6741'
 
 jobs:
   get-version:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -11,6 +11,10 @@ on:
         description: 'Version of CLI tool'
         required: true
         type: string
+ pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   build_and_publish_pilotcli_image:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -83,7 +83,7 @@ jobs:
             # Note: tags has to be all lower-case
             tags: ${{ steps.meta.outputs.tags }}
             # build on feature branches, push only on main branch
-            push: false
+            push: true
             load: true
             build-args: |
               CLI_VERSION=${{ github.event.inputs.release }}

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Docker Image
 
 on:
+ pull_request:
  workflow_dispatch:
     inputs:
       os:
@@ -23,7 +24,7 @@ on:
 jobs:
   get-version:
     name: Get pilot cli version
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     outputs:
       cli_version: ${{steps.get-version.outputs.cli_version}}
     steps:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -7,55 +7,98 @@ on:
         description: 'Operating system of CLI binary'
         required: true
         type: string
-      version:
-        description: 'Version of CLI tool'
+      release:
+        description: 'Release version of CLI tool'
         required: true
         type: string
+      docker_registry:
+        description: 'Registry endpoint to where to push the images.'
+        type: string
+        required: false
+        default: "indocpilot.azurecr.io"
 
 jobs:
-  build_and_publish_pilotcli_image:
-    uses: PilotDataPlatform/shared-ci-tools/.github/workflows/reusable_docker_build.yml@main
-    with:
-      docker_registry: 'indocpilot.azurecr.io'
-      image_name: 'pilotcli'
-      image_tag: "${{ github.event.inputs.os }}-${{ github.event.inputs.version }}"
-      dockerfile_path: '.'
-    secrets:
-      docker_registry_username: ${{ secrets.ACR_CLIENT }}
-      docker_registry_password: ${{ secrets.ACR_SECRET }}
+  get-version:
+    name: Get pilot cli version
+    runs-on: ubuntu-24.04
+    outputs:
+      cli_version: "${{ github.event.inputs.os }}-${{ github.event.inputs.release }}"
+  build-and-push-docker-image:
+      needs: [get-version-tag]
+      name: Build Docker images and push to repositories
+      runs-on: ubuntu-20.04
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ github.sha }}  # Ensures the workflow checks out the commit it was triggered on
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v2
+        - name: Login to Github Packages
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ inputs.docker_registry }}
+            username: ${{ secrets.docker_registry_username }}
+            password: ${{ secrets.docker_registry_password }}
+        - name: Docker metadata
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            # list of Docker images to use as base name for tags
+            images: |
+              ${{ inputs.docker_registry }}/pilotcli
+            # generate Docker tags based on the following events/attributes
+            sep-tags: ','
+            tags: |
+              type=raw,prefix=,suffix=,value=${{needs.get-version.outputs.cli_version}}
+        - name: Image digest
+          run: echo ${{ steps.meta.outputs.tags }}
+        - name: Check if image exists
+          id: check_image
+          run: |
+            exists=$(docker manifest inspect ${{ inputs.docker_registry }}/pilotcli:${{needs.get-version.outputs.cli_version}} > /dev/null && echo "true" || echo "false")
+            if [[ $exists == "true" ]]; then
+              echo "Image exists, aborting"
+              exit 1
+            fi
+        - name: Build image and push to GitHub Container Registry
+          uses: docker/build-push-action@v4
+          with:
+            # relative path to the place where source code with Dockerfile is located
+            context: .
+            # Note: tags has to be all lower-case
+            tags: ${{ steps.meta.outputs.tags }}
+            # build on feature branches, push only on main branch
+            push: false
+            build-args: |
+              CLI_VERSION=${{ github.event.inputs.release }}
+        - name: Run Trivy vulnerability scanner
+          uses: aquasecurity/trivy-action@0.24.0
+          with:
+            image-ref: '${{ steps.meta.outputs.tags }}'
+            format: 'table'
+            severity: 'CRITICAL'
+            exit-code: '1'
+            hide-progress: true
+            trivyignores: .github/.trivyignore
+            output: scan-results.txt
+          env:
+            TRIVY_IGNORE_STATUS: 'will_not_fix'
+            TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db:2'
 
-  run-trivy:
-    needs: [ build_and_publish_pilotcli_image ]
-    name: Run Trivy vulnerability scanner and publish scan results
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: '${{ needs.build_and_publish_pilotcli_image.steps.meta.outputs.tags }}'
-          format: 'table'
-          severity: 'CRITICAL'
-          exit-code: '1'
-          hide-progress: true
-          trivyignores: .github/.trivyignore
-          output: scan-results.txt
-        env:
-          TRIVY_IGNORE_STATUS: 'will_not_fix'
-          TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db:2'
-
-      - name: Publish Trivy Scan Results to Summary
-        if: always()
-        run: |
-          if [[ -s scan-results.txt ]]; then
-            {
-              echo "### Trivy Scan Results"
-              echo "Please refer to https://indocconsortium.atlassian.net/wiki/spaces/PILOT/pages/3917316126/Trivy+reports+triage to find out the next steps to fix the vulnerabilities"
-              echo "<details><summary>Click to expand</summary>"
-              echo ""
-              echo '```workflow-manager'
-              cat scan-results.txt
-              echo '```'
-              echo "</details>"
-            } >> $GITHUB_STEP_SUMMARY
-          fi
+        - name: Publish Trivy Scan Results to Summary
+          if: always()
+          run: |
+            if [[ -s scan-results.txt ]]; then
+              {
+                echo "### Trivy Scan Results"
+                echo "Please refer to https://indocconsortium.atlassian.net/wiki/spaces/PILOT/pages/3917316126/Trivy+reports+triage to find out the next steps to fix the vulnerabilities"
+                echo "<details><summary>Click to expand</summary>"
+                echo ""
+                echo '```workflow-manager'
+                cat scan-results.txt
+                echo '```'
+                echo "</details>"
+              } >> $GITHUB_STEP_SUMMARY
+            fi

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -16,6 +16,7 @@ on:
         type: string
         required: false
         default: "indocpilot.azurecr.io"
+ pull_request:
 
 jobs:
   get-version:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -22,9 +22,19 @@ jobs:
     name: Get pilot cli version
     runs-on: ubuntu-24.04
     outputs:
-      cli_version: "${{ github.event.inputs.os }}-${{ github.event.inputs.release }}"
+      cli_version: ${{steps.get-version.outputs.cli_version}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}  # Ensures the workflow checks out the commit it was triggered on
+      - name: Get Version
+        id: get-version
+        shell: bash
+        run: |
+          echo "cli_version=${{ github.event.inputs.os }}-${{ github.event.inputs.release }}" >> $GITHUB_OUTPUT
   build-and-push-docker-image:
-      needs: [get-version-tag]
+      needs: [get-version]
       name: Build Docker images and push to repositories
       runs-on: ubuntu-20.04
       steps:

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -11,6 +11,9 @@ on:
         description: 'Version of CLI tool'
         required: true
         type: string
+ pull_request:
+   branches:
+     - PILOT-6741
 
 jobs:
   build_and_publish_pilotcli_image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VER
     --output /usr/local/bin/pilotcli
 
 RUN chmod +x /usr/local/bin/pilotcli
+
+RUN pilotcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM indocpilot.azurecr.io/base-image/python:3.10.15-v1 AS base-image
+
+ARG CLI_VERSION
+
+RUN addgroup --system indoc && \
+    useradd --gid indoc --system --shell /bin/bash indoc
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        curl
+
+RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VERSION}/pilotcli_cloud \
+    --output /usr/local/bin/pilotcli
+
+RUN chmod +x /usr/local/bin/pilotcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:24.04
 
 ARG CLI_VERSION
+ARG CLI_OS
 
 RUN apt-get update \
      && apt-get install -y curl;
 
-RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VERSION}/pilotcli_linux \
+RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VERSION}/pilotcli_${CLI_OS} \
     --output /usr/local/bin/pilotcli
 
 RUN chmod +x /usr/local/bin/pilotcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,3 @@ RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VER
     --output /usr/local/bin/pilotcli
 
 RUN chmod +x /usr/local/bin/pilotcli
-
-RUN pilotcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-FROM indocpilot.azurecr.io/base-image/python:3.10.15-v1 AS base-image
+FROM ubuntu:24.04
 
 ARG CLI_VERSION
 
-RUN addgroup --system indoc && \
-    useradd --gid indoc --system --shell /bin/bash indoc
-
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        build-essential \
-        curl
+     && apt-get install -y curl;
 
-RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VERSION}/pilotcli_cloud \
+RUN curl -L https://github.com/PilotDataPlatform/cli/releases/download/${CLI_VERSION}/pilotcli_linux \
     --output /usr/local/bin/pilotcli
 
 RUN chmod +x /usr/local/bin/pilotcli


### PR DESCRIPTION
## Summary

* Add CI for building and pushing CLI docker image

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-6741

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

Tested CI using github cli, as `workflow_dispatch` with inputs cannot be tested in any branch expect main (this is a github UI limitation). Therefore, I tested this as follows:
```
gh workflow run .github/workflows/build-and-publish-docker.yml --ref PILOT-6741 -f os=cloud -f release=3.5.3
```
Job from test above can be found here: https://github.com/PilotDataPlatform/cli/actions/runs/12777976808/job/35619904228