### PR TITLE
PILOT-6724: add hard limit for queueing jobs into thread pool

### DIFF
--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -26,6 +26,8 @@ class AppConfig:
         green_zone = 'greenroom'
         core_bucket_prefix = 'core'
         greenroom_bucket_prefix = 'gr'
+        # the number of items to active interative mode
+        interative_threshold = 10
         # set hard limit for pending jobs, otherwise cli will consume all memory
         # to cache jobs. If later on the speed of chunk deliver become faster, we
         # can increase the concurrency number.

--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -26,8 +26,10 @@ class AppConfig:
         green_zone = 'greenroom'
         core_bucket_prefix = 'core'
         greenroom_bucket_prefix = 'gr'
-        # the number of items to active interative mode
-        interative_threshold = 10
+        # set hard limit for pending jobs, otherwise cli will consume all memory
+        # to cache jobs. If later on the speed of chunk deliver become faster, we
+        # can increase the concurrency number.
+        num_of_jobs = 20
 
         github_url = 'PilotDataPlatform/cli'
 

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -67,8 +67,6 @@ class UploadClient(BaseAuthClient):
         self.user = UserConfig()
         self.operator = self.user.username
         self.chunk_size = AppConfig.Env.chunk_size
-        # this indicate when we check the applied sync in pool
-        self.threadpool_check = 20
 
         prefix = {
             AppConfig.Env.green_zone: AppConfig.Env.greenroom_bucket_prefix,

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import math
 import os
+import threading
 import time
 from logging import getLogger
 from multiprocessing.pool import ApplyResult
@@ -66,6 +67,8 @@ class UploadClient(BaseAuthClient):
         self.user = UserConfig()
         self.operator = self.user.username
         self.chunk_size = AppConfig.Env.chunk_size
+        # this indicate when we check the applied sync in pool
+        self.threadpool_check = 20
 
         prefix = {
             AppConfig.Env.green_zone: AppConfig.Env.greenroom_bucket_prefix,
@@ -302,6 +305,10 @@ class UploadClient(BaseAuthClient):
                 been uploaded.
         """
         count = 0
+        semaphore = threading.Semaphore(AppConfig.Env.num_of_jobs)
+
+        def on_complete(result):
+            semaphore.release()
 
         # process on the file content
         f = open(file_object.local_path, 'rb')
@@ -327,9 +334,11 @@ class UploadClient(BaseAuthClient):
                 chunk_size = chunk_info.get('chunk_size', self.chunk_size)
                 file_object.update_progress(chunk_size)
             else:
+                semaphore.acquire()
                 res = pool.apply_async(
                     self.upload_chunk,
                     args=(file_object, count + 1, chunk, local_chunk_etag, len(chunk)),
+                    callback=on_complete,
                 )
                 chunk_result.append(res)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.11.0"
+version = "3.12.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_dataset.py
+++ b/tests/app/commands/test_dataset.py
@@ -31,7 +31,6 @@ def test_dataset_list_total_less_than_10(mocker, cli_runner):
     question_mock = mocker.patch.object(questionary, 'select', return_value=questionary.select)
 
     result = cli_runner.invoke(dataset_list, ['--page', 0, '--page-size', page_size])
-
     assert result.exit_code == 0
     assert '' == result.output
     assert question_mock.call_count == 0


### PR DESCRIPTION
## Summary

After testing, the issue is only limited in windows platform, which doesn’t have hard limit of memory usage of each process. It will allow cli to use memory as much as possible, while linux will have around 8GB memory budge for it. However, the issue is not only limited with system setups, the code logic itself has huge defect which cli shouldn’t use that much memory at all. After investigation, the issue was caused by improper logic inside threading chunk upload. Cli uses apply_aync function to queue chunk uploading functions chunk_upload. Cli will keep creating function into pool and those function will be hold by memory until reaching limits. 

The problem is here: The function chunk_upload will take chunk as parameter, that means it will use memory to hold chunk (partial of the file). The job creating speed is way more faster than job consuming speed(job uploading). Therefore, it eventually eats up all memory budget. 

The solution is to limit the number of waiting job (concurrency) by semaphore package. I made following test regarding with different threading number:

    threading 2 with 20 waiting jobs limitation.

    threading 6 with 20 waiting jobs limitation.

In both cases, the job creation speed is much faster than its consumption speed. And there is no performance drop. So I decided to create a default envvar num_of_jobs with default number 20, which we can adjust it a later if users need higher number of waiting jobs.

## JIRA Issues

PILOT-6724

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

No test cases updated
