### PR TITLE
patch20250130: make the concurrency of uploading jobsbs configurable

### DIFF
--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -31,7 +31,7 @@ class AppConfig:
         # set hard limit for pending jobs, otherwise cli will consume all memory
         # to cache jobs. If later on the speed of chunk deliver become faster, we
         # can increase the concurrency number.
-        num_of_jobs = 20
+        num_of_jobs = ConfigClass.concurrent_job_limit
 
         github_url = 'PilotDataPlatform/cli'
 

--- a/app/configs/app_config.py
+++ b/app/configs/app_config.py
@@ -13,7 +13,7 @@ class AppConfig:
         # NOTE: there is a limitation on minio that
         # the multipart number is 10000. so we set
         # the chunk_size as 20MB -> total 200GB
-        chunk_size = 1024 * 1024 * 20  # MB
+        chunk_size = ConfigClass.upload_chunk_size  # MB
         resilient_retry = 3
         resilient_backoff = 1
         resilient_retry_interval = 1  # seconds

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     apikey_endpoint: str = 'api-key'
 
     upload_batch_size: int = 100
+    concurrent_job_limit: int = 10
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/app/configs/config.py
+++ b/app/configs/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
 
     upload_batch_size: int = 100
     concurrent_job_limit: int = 10
+    upload_chunk_size: int = 1024 * 1024 * 20  # 20MB
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.12.0"
+version = "3.12.1"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

After testing, we found jhub cant support 20 waiting job which is 400MB memory usage. Therefore, reduce the default number to 10 and make the number of waiting job configurable. 

## JIRA Issues

(What JIRA issues this merge request is related to)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

No test
