### PR TITLE
Patch20250327: change workflow to push back to feature branch during PR

### DIFF
--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -2,16 +2,9 @@ name: Update Compatible Versions
 
 on:
   workflow_run:
-    workflows: [ "Run Tests" ]
-    branches:
-      - develop
+    workflows: ["Run Tests"]
     types:
       - completed
-
-  pull_request:
-    branches:
-      - main
-      - develop
 
 jobs:
   update-compatible-versions:
@@ -22,7 +15,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Extract Versions from PR
         id: extract_versions
@@ -90,5 +82,3 @@ jobs:
       - name: Push change to feature branch
         run: |
           git push origin HEAD:${{ github.head_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Commit and Push Changes
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@users.noreply.indocresearch.org"
           git add docs/compatible_version.ndjson README.md
           git commit -m "Updated docs/compatible_version.ndjson with PR #${{ github.event.pull_request.number }}"
           git push

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Extract Versions from PR
         id: extract_versions
@@ -80,6 +83,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "github-actions@users.noreply.indocresearch.org"
+          git pull origin ${{ github.head_ref }}
           git add docs/compatible_version.ndjson README.md
           git commit -m "Updated docs/compatible_version.ndjson with PR #${{ github.event.pull_request.number }}"
 

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -1,11 +1,6 @@
 name: Update Compatible Versions
 
 on:
-  workflow_run:
-    workflows: ["Run Tests"]
-    types:
-      - completed
-
   pull_request:
     branches:
       - main

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -38,7 +38,7 @@ jobs:
           COMPATIBLE_VERSION=${COMPATIBLE_VERSION:-"Unknown"}
 
           # Get the latest Git tag (assuming it's the CLI version)
-          LATEST_CLI_VERSION=$(poetry version --short || echo "Unknown")
+          LATEST_CLI_VERSION=$(grep '^version =' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
 
           # Convert to NDJSON format
           NEW_ENTRY="{\"Cli Version\": \"$LATEST_CLI_VERSION\", \"Pilot Release Version\": \"$CLI_VERSION\", \"Compatible Version\": \"$COMPATIBLE_VERSION\"}"

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
 
+  pull_request:
+    branches:
+      - main
+      - develop
+
 jobs:
   update-compatible-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -2,19 +2,19 @@ name: Update Compatible Versions
 
 on:
   workflow_run:
-    workflows: [ "Build and Publish" ]
+    workflows: [ "Run Tests" ]
     branches:
       - develop
     types:
       - completed
 
   pull_request:
-    types:
-      - closed    # Ensures it runs only on PR closure (merge)
+    branches:
+      - main
+      - develop
 
 jobs:
   update-compatible-versions:
-    if: github.event.pull_request.merged == true  # Runs only if PR is merged
     runs-on: ubuntu-latest
 
     steps:
@@ -82,5 +82,9 @@ jobs:
           git config user.email "github-actions@users.noreply.indocresearch.org"
           git add docs/compatible_version.ndjson README.md
           git commit -m "Updated docs/compatible_version.ndjson with PR #${{ github.event.pull_request.number }}"
-          git push
-        continue-on-error: true  # Avoid breaking workflow if no changes detected
+
+      - name: Push change to feature branch
+        run: |
+          git push origin HEAD:${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.16.0 | 2.15 | 2.15 |
 | 3.17.0 | 2.15 | 2.15 |
 | 3.17.1 | 2.15 | 2.15 |
+| 3.17.1 | 2.15 | 2.15 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@ Command line tool that allows the user to execute data operations on the platfor
 
 ## Compatible versions
 <!-- COMPATIBLE_VERSIONS_START -->
-
+| Cli Version | Pilot Release Version | Compatible Version |
+|------------|----------------------|---------------------|
+| 3.15.0 | 2.14.2 | 2.14.2 |
+| 3.15.1 | 2.14.2 | 2.14.2 |
+| 3.15.2 | 2.15 | 2.15 |
+| 3.16.0 | 2.15 | 2.15 |
+| 3.17.0 | 2.15 | 2.15 |
+| 3.17.1 | 2.15 | 2.15 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -4,3 +4,4 @@
 {"Cli Version": "3.16.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.17.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.17.1", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
+{"Cli Version": "3.17.1", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -3,3 +3,4 @@
 {"Cli Version": "3.15.2", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.16.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.17.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
+{"Cli Version": "3.17.1", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}


### PR DESCRIPTION
## Summary

Because the development branch is protected, now change workflow to push back to feature branch during PR instead of directly push into develop branch.

## JIRA Issues

PILOT-7234

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)

## Versions

- Pilot Release Version: 2.15
- Compatible Version: 2.15
