### PR TITLE
Pilot 7388: update cli preupload logic to attach attribute template

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.17.0 | 2.15 | 2.15 |
 | 3.17.1 | 2.15 | 2.15 |
 | 3.17.2 | 2.15 | 2.15 |
+| 3.18.0 | 2.15 | 2.15 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -233,7 +233,7 @@ def file_put(**kwargs):  # noqa: C901
         if source_file:
             upload_event['source_id'] = src_file_info
 
-        _ = simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
+        simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
         message_handler.SrvOutPutHandler.all_file_uploaded()
         remove_the_output_file(output_path)
 

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -234,11 +234,7 @@ def file_put(**kwargs):  # noqa: C901
             upload_event['source_id'] = src_file_info
 
         _ = simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
-
-        # since only file upload can attach manifest, take the first file object
-        # srv_manifest.attach_manifest(attribute, item_ids[0], zone) if attribute else None
         message_handler.SrvOutPutHandler.all_file_uploaded()
-
         remove_the_output_file(output_path)
 
 
@@ -284,13 +280,6 @@ def file_resume(**kwargs):  # noqa: C901
         validate_upload_event(resumable_manifest)
 
     resume_upload(resumable_manifest, thread)
-
-    # since only file upload can attach manifest, take the first file object
-    # srv_manifest = SrvFileManifests()
-    # item_id = next(iter(resumable_manifest.get('registered_items')))
-    # attribute = resumable_manifest.get('attributes')
-    # zone = resumable_manifest.get('zone')
-    # srv_manifest.attach_manifest(attribute, item_id, zone) if attribute else None
     message_handler.SrvOutPutHandler.all_file_uploaded()
 
     remove_the_output_file(resumable_manifest_file)

--- a/app/commands/file.py
+++ b/app/commands/file.py
@@ -176,7 +176,6 @@ def file_put(**kwargs):  # noqa: C901
         exit(1)
 
     project_code, folder_type, target_folder = identify_target_folder(project_path)
-    srv_manifest = SrvFileManifests()
     upload_val_event = {
         'zone': zone,
         'source': source_files,
@@ -234,10 +233,10 @@ def file_put(**kwargs):  # noqa: C901
         if source_file:
             upload_event['source_id'] = src_file_info
 
-        item_ids = simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
+        _ = simple_upload(upload_event, num_of_thread=thread, output_path=output_path)
 
         # since only file upload can attach manifest, take the first file object
-        srv_manifest.attach_manifest(attribute, item_ids[0], zone) if attribute else None
+        # srv_manifest.attach_manifest(attribute, item_ids[0], zone) if attribute else None
         message_handler.SrvOutPutHandler.all_file_uploaded()
 
         remove_the_output_file(output_path)
@@ -287,11 +286,11 @@ def file_resume(**kwargs):  # noqa: C901
     resume_upload(resumable_manifest, thread)
 
     # since only file upload can attach manifest, take the first file object
-    srv_manifest = SrvFileManifests()
-    item_id = next(iter(resumable_manifest.get('registered_items')))
-    attribute = resumable_manifest.get('attributes')
-    zone = resumable_manifest.get('zone')
-    srv_manifest.attach_manifest(attribute, item_id, zone) if attribute else None
+    # srv_manifest = SrvFileManifests()
+    # item_id = next(iter(resumable_manifest.get('registered_items')))
+    # attribute = resumable_manifest.get('attributes')
+    # zone = resumable_manifest.get('zone')
+    # srv_manifest.attach_manifest(attribute, item_id, zone) if attribute else None
     message_handler.SrvOutPutHandler.all_file_uploaded()
 
     remove_the_output_file(resumable_manifest_file)

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -11,7 +11,6 @@ from app.models.service_meta_class import MetaService
 from app.services.clients.base_auth_client import BaseAuthClient
 from app.services.output_manager.error_handler import ECustomizedError
 from app.services.output_manager.error_handler import SrvErrorHandler
-from app.services.user_authentication.decorator import require_valid_token
 
 
 def dupe_checking_hook(pairs):
@@ -47,22 +46,6 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
         obj = json.loads(data)
         return obj
 
-    @require_valid_token()
-    def validate_template(self, manifest_json):
-        try:
-            res = self._post('validate/manifest', json=manifest_json)
-        except Exception as e:
-            response = e.response
-            if response.status_code == 200:
-                result = res.json()['result']
-                message_handler.SrvOutPutHandler.file_manifest_validation(result)
-                return result == 'valid', result
-            elif response.status_code == 403:
-                SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, self.interactive)
-
-        return False, res.content
-
-    @require_valid_token()
     def attach(self, manifest_json: dict, item_id: str, zone: str):
         manifest_json.update({'item_id': item_id, 'zone': zone})
         try:
@@ -76,17 +59,15 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
         result['code'] = res.status_code
         return result
 
-    @require_valid_token()
-    def list_manifest(self, project_code):
+    def list_manifest(self, project_code, manifest_name=None):
         try:
-            res = self._get('manifest', params={'project_code': project_code})
+            res = self._get('manifest', params={'project_code': project_code, 'manifest_name': manifest_name})
         except Exception as e:
             error_msg = e.response.json().get('error_msg')
             SrvErrorHandler.default_handle(f'List Manifest Failed: {error_msg}', True)
 
         return res
 
-    @require_valid_token()
     def export_manifest(self, project_code, attribute_name):
         try:
             res = self._get('manifest/export', params={'project_code': project_code, 'name': attribute_name})
@@ -136,16 +117,22 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
     def validate_manifest(self, manifest, raise_error=True):
         manifest_validation_event = {'manifest_json': manifest}
-        validation = self.validate_template(manifest_validation_event)
-        if not validation[0]:
-            validation_result = validation[1].get('error_msg').split(' ')
-            error_attr = '_'.join(validation_result[:-1]).upper()
-            validation_error = getattr(ECustomizedError, error_attr)
-            SrvErrorHandler.customized_handle(validation_error, raise_error, validation_result[-1])
-        else:
-            validation = [True]
-            validation_error = ''
-        return validation, validation_error
+        result, validation_error = '', None
+        try:
+            res = self._post('validate/manifest', json=manifest_validation_event)
+            message_handler.SrvOutPutHandler.file_manifest_validation(res.status_code == 200)
+            result = res.json()
+        except Exception as e:
+            response = e.response
+            if response.status_code == 403:
+                SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, self.interactive)
+            elif response.status_code == 400:
+                validation_result = response.json.get('error_msg').split(' ')
+                error_attr = '_'.join(validation_result[:-1]).upper()
+                validation_error = getattr(ECustomizedError, error_attr)
+                SrvErrorHandler.customized_handle(validation_error, raise_error, validation_result[-1])
+
+        return result, validation_error
 
     def attach_manifest(self, manifest: dict, item_id: str, zone: str):
         res = self.attach(manifest, item_id, zone)

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -46,20 +46,6 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
         obj = json.loads(data)
         return obj
 
-    def validate_template(self, manifest_json):
-        try:
-            res = self._post('validate/manifest', json=manifest_json)
-        except Exception as e:
-            response = e.response
-            if response.status_code == 200:
-                result = res.json()['result']
-                message_handler.SrvOutPutHandler.file_manifest_validation(result)
-                return result == 'valid', result
-            elif response.status_code == 403:
-                SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, self.interactive)
-
-        return False, res.content
-
     def attach(self, manifest_json: dict, item_id: str, zone: str):
         manifest_json.update({'item_id': item_id, 'zone': zone})
         try:
@@ -110,7 +96,27 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
     @staticmethod
     def convert_import(user_defined: dict, project_code):
-        # convert the user defined json file to attach post json
+        '''
+        Summary:
+            convert the user defined json file to attach post json
+        Args:
+            user_defined: dict, the user defined json file. Example:
+                {
+                    "manifest_name": {
+                        "attribute_name": "value"
+                    }
+                }
+            project_code: str, the project code
+        Return:
+            dict, the attach post json. Example：
+                {
+                    "manifest_name": "manifest_name",
+                    "project_code": "project_code",
+                    "attributes": {
+                        "attribute_name": "value"
+                    }
+                }
+        '''
         converted_attrs = {}
         keys = list(user_defined.keys())
         mani_name = keys[0]
@@ -121,7 +127,35 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
     @staticmethod
     def convert_export(attach_post: dict):
-        # convert the attach post json to user defined json
+        ''' '
+        Summary:
+            convert the attach post json to user defined json file'
+        Args:
+            attach_post: dict, the attach post json. Example:
+            {
+                "id": "0ed17361-01a8-4a1b-9810-fcecf07ddad4",
+                "name": "test123",
+                "project_code": "tp01",
+                "attributes": [
+                    {
+                        "name": "regex",
+                        "optional": true,
+                        "type": "regex",
+                        "options": null,
+                        "pattern": "[A-Z]",
+                        "sample": "ABC",
+                        "description": "Capitalized word only"
+                    }
+                ]
+            }
+        Return:
+            dict, the user defined json file. Example:
+                {
+                    "manifest_name": {
+                        "attribute_name": "" # empty string
+                    }
+                }
+        '''
         converted = {}
         name = attach_post['name']
         converted[name] = {}

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -37,6 +37,7 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
         self.interactive = interactive
         self.endpoint = self.app_config.Connections.url_bff + '/v1'
+        self.endpoint = 'http://localhost:5080/v1'
 
     @staticmethod
     def read_manifest_template(path):
@@ -48,39 +49,53 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
     @require_valid_token()
     def validate_template(self, manifest_json):
-        res = self._post('validate/manifest', json=manifest_json)
-        if res.status_code == 200:
-            result = res.json()['result']
-            message_handler.SrvOutPutHandler.file_manifest_validation(result)
-            return result == 'valid', result
-        elif res.status_code == 403:
-            SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, self.interactive)
+        try:
+            res = self._post('validate/manifest', json=manifest_json)
+        except Exception as e:
+            response = e.response
+            if response.status_code == 200:
+                result = res.json()['result']
+                message_handler.SrvOutPutHandler.file_manifest_validation(result)
+                return result == 'valid', result
+            elif response.status_code == 403:
+                SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, self.interactive)
 
         return False, res.content
 
     @require_valid_token()
     def attach(self, manifest_json: dict, item_id: str, zone: str):
         manifest_json.update({'item_id': item_id, 'zone': zone})
-        res = self._post('manifest/attach', json=manifest_json)
-        if res.status_code == 200:
-            result = res.json()
-            result['code'] = res.status_code
-            return result
+        try:
+            res = self._post('manifest/attach', json=manifest_json)
+        except Exception as e:
+            error_msg = e.response.json().get('error_msg')
+            SrvErrorHandler.default_handle(f'Attribute Attach Failed: {error_msg}', True)
+            return None
 
-        return None
+        result = res.json()
+        result['code'] = res.status_code
+        return result
 
     @require_valid_token()
     def list_manifest(self, project_code):
-        res = self._get('manifest', params={'project_code': project_code})
+        try:
+            res = self._get('manifest', params={'project_code': project_code})
+        except Exception as e:
+            error_msg = e.response.json().get('error_msg')
+            SrvErrorHandler.default_handle(f'List Manifest Failed: {error_msg}', True)
+
         return res
 
     @require_valid_token()
     def export_manifest(self, project_code, attribute_name):
-        res = self._get('manifest/export', params={'project_code': project_code, 'name': attribute_name})
-        if res.status_code == 404:
-            SrvErrorHandler.customized_handle(ECustomizedError.MANIFEST_NOT_EXIST, True, value=attribute_name)
-        elif res.status_code == 403:
-            SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, True)
+        try:
+            res = self._get('manifest/export', params={'project_code': project_code, 'name': attribute_name})
+        except Exception as e:
+            response = e.response
+            if response.status_code == 404:
+                SrvErrorHandler.customized_handle(ECustomizedError.MANIFEST_NOT_EXIST, True, value=attribute_name)
+            elif response.status_code == 403:
+                SrvErrorHandler.customized_handle(ECustomizedError.CODE_NOT_FOUND, True)
 
         return res.json().get('result')
 

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -45,7 +45,22 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
         obj = json.loads(data)
         return obj
 
-    def attach(self, manifest_json: dict, item_id: str, zone: str):
+    def attach(self, manifest_json: dict, item_id: str, zone: str) -> dict[str, str]:
+        '''
+        Summary:
+            function will call to attach the manifest to the item
+        Args:
+            manifest_json: dict, the manifest json file. Example:
+                {
+                    "manifest_name": {
+                        "attribute_name": "value"
+                    }
+                }
+            item_id: str, the item id
+            zone: str, the zone name
+        Return:
+            dict, the attach post json. Example：
+        '''
         manifest_json.update({'item_id': item_id, 'zone': zone})
         try:
             res = self._post('manifest/attach', json=manifest_json)

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -36,7 +36,6 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
         self.interactive = interactive
         self.endpoint = self.app_config.Connections.url_bff + '/v1'
-        # self.endpoint = 'http://localhost:5080/v1'
 
     @staticmethod
     def read_manifest_template(path):

--- a/app/services/file_manager/file_manifests.py
+++ b/app/services/file_manager/file_manifests.py
@@ -36,7 +36,7 @@ class SrvFileManifests(BaseAuthClient, metaclass=MetaService):
 
         self.interactive = interactive
         self.endpoint = self.app_config.Connections.url_bff + '/v1'
-        self.endpoint = 'http://localhost:5080/v1'
+        # self.endpoint = 'http://localhost:5080/v1'
 
     @staticmethod
     def read_manifest_template(path):

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -187,7 +187,7 @@ def simple_upload(  # noqa: C901
     compress_zip = upload_event.get('compress_zip', False)
     regular_file = upload_event.get('regular_file', True)
     source_id = upload_event.get('source_id', '')
-    attribute = upload_event.get('attribute')
+    attribute = upload_event.get('attribute', {})
 
     mhandler.SrvOutPutHandler.start_uploading(input_path)
     # if the input request zip folder then process the path as single file

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -252,7 +252,7 @@ def simple_upload(  # noqa: C901
     for file_batchs in batch_generator(non_duplicate_file_objects, batch_size=AppConfig.Env.upload_batch_size):
         # sending the pre upload request to generate
         # the placeholder in object storage
-        pre_upload_infos.extend(upload_client.pre_upload(file_batchs, output_path))
+        pre_upload_infos.extend(upload_client.pre_upload(file_batchs))
 
         # then output manifest file to the output path AFTER EACH BATCH
         # which will include unfinished objects
@@ -411,7 +411,7 @@ def resume_upload(
     batch_count = 1
     resumable_manifest_file = manifest_json.get('resumable_manifest_file')
     for file_batchs in batch_generator(unregistered_items, batch_size=AppConfig.Env.upload_batch_size):
-        unfinished_items.extend(upload_client.pre_upload(file_batchs, resumable_manifest_file))
+        unfinished_items.extend(upload_client.pre_upload(file_batchs))
         upload_client.output_manifest(unfinished_items, unregistered_items[batch_count + 1 :], resumable_manifest_file)
         batch_count += 1
 

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -34,7 +34,7 @@ from app.utils.aggregated import normalize_join
 from app.utils.aggregated import search_item
 
 
-def compress_folder_to_zip(path):
+def compress_folder_to_zip(path: str) -> str:
     path = path.rstrip('/').lstrip()
     zipfile_path = path + '.zip'
     mhandler.SrvOutPutHandler.start_zipping_file()
@@ -43,6 +43,7 @@ def compress_folder_to_zip(path):
         for file in files:
             zipf.write(os.path.join(root, file))
     zipf.close()
+    return zipfile_path
 
 
 def assemble_path(

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -203,13 +203,12 @@ class UploadClient(BaseAuthClient):
         return list(object_path_file_object_map.values()), exist_files
 
     @require_valid_token()
-    def pre_upload(self, file_objects: List[FileObject], output_path: str) -> List[FileObject]:
+    def pre_upload(self, file_objects: List[FileObject]) -> List[FileObject]:
         """
         Summary:
             The function is to initiate all the multipart upload.
         Parameter:
             - local_file_paths(list of str): the local path of files to be uploaded.
-            - output_path(str): the output path of manifest.
         return:
             - list of FileObject: the infomation retrieved from backend.
                 - resumable_id(str): the unique identifier for multipart upload.
@@ -233,22 +232,24 @@ class UploadClient(BaseAuthClient):
         }
         if self.source_id:
             payload.update({'source_id': self.source_id})
+        if self.attributes:
+            payload.update({'attributes_template': self.attributes})
 
         try:
-            self.endpoint = AppConfig.Connections.url_bff + '/v1'
+            # self.endpoint = AppConfig.Connections.url_bff + '/v1'
+            self.endpoint = 'http://localhost:5080/v1'
             response = self._post(f'project/{self.project_code}/files', json=payload)
         except HTTPStatusError as e:
             response = e.response
             if response.status_code == 403:
                 SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, self.regular_file)
-            elif response.status_code == 401:
-                SrvErrorHandler.customized_handle(ECustomizedError.PROJECT_DENIED, self.regular_file)
             elif response.status_code == 409:
                 SrvErrorHandler.customized_handle(ECustomizedError.FILE_EXIST, self.regular_file)
             elif response.status_code == 400:
                 SrvErrorHandler.customized_handle(ECustomizedError.FILE_LOCKED, True)
-            elif response.status_code == 500:
-                SrvErrorHandler.customized_handle(ECustomizedError.FILE_LOCKED, True)
+            elif response.status_code == 422:
+                error_message = response.json().get('error_msg', {}).get('details')
+                SrvErrorHandler.customized_handle(ECustomizedError.INVALID_ATTRIBUTE, True, value=error_message)
             else:
                 SrvErrorHandler.default_handle(response.content, True)
 

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -236,8 +236,7 @@ class UploadClient(BaseAuthClient):
             payload.update({'attributes_template': self.attributes})
 
         try:
-            # self.endpoint = AppConfig.Connections.url_bff + '/v1'
-            self.endpoint = 'http://localhost:5080/v1'
+            self.endpoint = AppConfig.Connections.url_bff + '/v1'
             response = self._post(f'project/{self.project_code}/files', json=payload)
         except HTTPStatusError as e:
             response = e.response

--- a/app/services/file_manager/file_upload/upload_validator.py
+++ b/app/services/file_manager/file_upload/upload_validator.py
@@ -43,10 +43,23 @@ class UploadEventValidator:
         return source_ids
 
     def validate_attribute(self):
+        '''
+        Summary:
+            function will check if the attribute exists. And parse the
+            attribute to the correct format with manifest id.
+        Return:
+            attribute: dict, the attribute with manifest id
+            id: str, the manifest id
+        '''
         srv_manifest = SrvFileManifests()
         try:
-            attribute = srv_manifest.convert_import(self.attribute, self.project_code)
-            srv_manifest.validate_manifest(attribute)
+            manifest = srv_manifest.convert_import(self.attribute, self.project_code)
+            res = srv_manifest.list_manifest(self.project_code, manifest.get('manifest_name'))
+            manifest_id = res.json().get('result')[0].get('id')
+            attribute = {
+                'id': manifest_id,
+                'attributes': manifest.get('attributes'),
+            }
             return attribute
         except Exception:
             SrvErrorHandler.customized_handle(ECustomizedError.INVALID_TEMPLATE, True)

--- a/app/services/file_manager/file_upload/upload_validator.py
+++ b/app/services/file_manager/file_upload/upload_validator.py
@@ -56,6 +56,7 @@ class UploadEventValidator:
             manifest = srv_manifest.convert_import(self.attribute, self.project_code)
             res = srv_manifest.list_manifest(self.project_code, manifest.get('manifest_name'))
             manifest_id = res.json().get('result')[0].get('id')
+
             attribute = {
                 'id': manifest_id,
                 'attributes': manifest.get('attributes'),

--- a/app/services/output_manager/message_handler.py
+++ b/app/services/output_manager/message_handler.py
@@ -120,7 +120,7 @@ class SrvOutPutHandler(metaclass=MetaService):
     @staticmethod
     def file_manifest_validation(post_result):
         """e.g. File attribute validated: True."""
-        return logger.info(f'File attribute validation passed: {post_result == "valid"}')
+        return logger.info(f'File attribute validation passed: {post_result}')
 
     @staticmethod
     def uploading_files(uploader, project_code, resumable_total_size, resumable_total_chunks, resumable_relative_path):

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -5,3 +5,4 @@
 {"Cli Version": "3.17.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.17.1", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
 {"Cli Version": "3.17.2", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
+{"Cli Version": "3.18.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.17.2"
+version = "3.18.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/commands/test_file.py
+++ b/tests/app/commands/test_file.py
@@ -36,9 +36,6 @@ def test_file_upload_command_success_with_attribute(mocker, cli_runner, ending_s
     test_obj = FileObject('resumable_id', 'job_id', 'item_id', 'object/path', 'local_path')
 
     simple_upload_mock = mocker.patch('app.commands.file.simple_upload', return_value=[test_obj])
-    attribute_mock = mocker.patch(
-        'app.services.file_manager.file_manifests.SrvFileManifests.attach_manifest', return_value=None
-    )
 
     # create a test file
     runner = click.testing.CliRunner()
@@ -62,7 +59,6 @@ def test_file_upload_command_success_with_attribute(mocker, cli_runner, ending_s
 
     assert result.exit_code == 0
     simple_upload_mock.assert_called_once()
-    attribute_mock.assert_called_once()
 
 
 def test_file_upload_failed_with_invalid_tag_file(cli_runner):
@@ -217,16 +213,10 @@ def test_resumable_upload_command_with_file_attribute_success(mocker, cli_runner
             )
 
         mocker.patch('app.commands.file.resume_upload', return_value=None)
-
-        attribute_fun_mock = mocker.patch(
-            'app.services.file_manager.file_manifests.SrvFileManifests.attach_manifest', return_value=None
-        )
-
         mocker.patch('os.remove', return_value=None)
 
         result = cli_runner.invoke(file_resume, ['--resumable-manifest', 'test.json', '--thread', 1])
     assert result.exit_code == 0
-    attribute_fun_mock.assert_called_once()
 
 
 def test_resumable_upload_command_failed_with_file_not_exists(mocker, cli_runner):

--- a/tests/app/services/file_manager/file_upload/test_file_upload.py
+++ b/tests/app/services/file_manager/file_upload/test_file_upload.py
@@ -2,15 +2,52 @@
 #
 # Contact Indoc Systems for any questions regarding the use of this source code.
 
+import os
+
+import click
+
 from app.configs.app_config import AppConfig
 from app.models.item import ItemType
 from app.services.file_manager.file_upload.file_upload import assemble_path
+from app.services.file_manager.file_upload.file_upload import compress_folder_to_zip
 from app.services.file_manager.file_upload.file_upload import resume_upload
 from app.services.file_manager.file_upload.file_upload import simple_upload
 from app.services.file_manager.file_upload.models import FileObject
 from app.services.file_manager.file_upload.models import ItemStatus
 from app.services.output_manager.error_handler import ECustomizedError
 from app.services.output_manager.error_handler import customized_error_msg
+
+
+def test_compress_to_zip(mocker):
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        # create a test folder and file
+        test_folder = 'test_folder'
+        test_file_content = 'This is a test file.'
+        os.makedirs(test_folder, exist_ok=True)
+        for i in range(3):
+            with open(os.path.join(test_folder, f'test_file_{i}.txt'), 'w') as f:
+                f.write(test_file_content)
+
+        # compress the folder
+        zip_file_path = compress_folder_to_zip(test_folder)
+        assert os.path.exists(zip_file_path)
+        assert zip_file_path.endswith('.zip')
+
+        # check the content of the zip file
+        import zipfile
+
+        with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+            zip_content = zip_ref.namelist()
+            assert len(zip_content) == 3
+            for i in range(3):
+                assert f'{test_folder}/test_file_{i}.txt' in zip_content
+        # check the content of the files in the zip
+        for i in range(3):
+            with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+                with zip_ref.open(f'{test_folder}/test_file_{i}.txt') as f:
+                    content = f.read().decode('utf-8')
+                    assert content == test_file_content
 
 
 def test_assemble_path_at_name_folder(mocker):

--- a/tests/app/services/file_manager/test_manifest.py
+++ b/tests/app/services/file_manager/test_manifest.py
@@ -3,6 +3,7 @@
 # Contact Indoc Systems for any questions regarding the use of this source code.
 
 import json
+import os
 
 import click
 import pytest
@@ -137,3 +138,43 @@ def test_manifest_export_failure(httpx_mock, capfd, error_code, error_msg):
     except SystemExit:
         out, _ = capfd.readouterr()
         assert error_msg in out
+
+
+def test_export_template_success():
+    manifest = {
+        'name': 'test_manifest',
+        'project_code': 'test_project',
+        'attributes': [{'name': 'attribute1', 'value': 'value1'}],
+    }
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        srv_manifest = SrvFileManifests()
+        template_file, def_file = srv_manifest.export_template(manifest['project_code'], manifest)
+
+        # check if files are created
+        assert def_file == f'{manifest["project_code"]}_{manifest["name"]}_definition.json'
+        assert template_file == f'{manifest["project_code"]}_{manifest["name"]}_template.json'
+        assert os.path.exists(def_file)
+        assert os.path.exists(template_file)
+
+
+def test_convert_import():
+    srv_manifest = SrvFileManifests()
+    manifest = {
+        'test_manifest': {'attribute1': 'value1', 'attribute2': 'value2'},
+    }
+    converted = srv_manifest.convert_import(manifest, 'test_project')
+    assert converted['manifest_name'] == 'test_manifest'
+    assert converted['project_code'] == 'test_project'
+    assert converted['attributes']['attribute1'] == 'value1'
+
+
+def test_convert_export():
+    srv_manifest = SrvFileManifests()
+    attach_post = {
+        'name': 'test_manifest',
+        'project_code': 'test_project',
+        'attributes': [{'name': 'attribute1', 'value': 'value1'}],
+    }
+    converted = srv_manifest.convert_export(attach_post)
+    assert converted['test_manifest']['attribute1'] == ''

--- a/tests/app/services/file_manager/test_manifest.py
+++ b/tests/app/services/file_manager/test_manifest.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2025 Indoc Systems
+#
+# Contact Indoc Systems for any questions regarding the use of this source code.
+
+import json
+
+import click
+import pytest
+
+from app.services.file_manager.file_manifests import SrvFileManifests
+
+
+def test_read_manifest_template_success():
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        # Test reading a valid manifest template
+        path = 'test.json'
+        expected_output = {
+            'manifest_name': 'test_manifest',
+            'attributes': {'attribute1': 'value1', 'attribute2': 'value2'},
+        }
+        with open(path, 'w') as f:
+            json.dump(expected_output, f)
+
+        result = SrvFileManifests.read_manifest_template(path)
+        assert result == expected_output
+
+
+def test_read_manifest_template_duplicate_line():
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        # Test reading a manifest template with duplicate lines
+        path = 'test_duplicate.json'
+        invalid_json = '{"manifest_name": "test_manifest", "manifest_name": "test_manifest1"}'
+        with open(path, 'w') as f:
+            f.write(invalid_json)
+
+        with pytest.raises(KeyError):
+            SrvFileManifests.read_manifest_template(path)
+
+
+def test_manifest_listing_success_under_project(httpx_mock):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP GET request
+    httpx_mock.add_response(
+        method='GET',
+        url=f'{srv_manifest.endpoint}/manifest?project_code=test_project&manifest_name=',
+        json={'result': [{'id': '123', 'manifest_name': 'test_manifest', 'attributes': {'attribute1': 'value1'}}]},
+        status_code=200,
+    )
+
+    response = srv_manifest.list_manifest('test_project')
+    assert response.status_code == 200
+    assert response.json()['result'][0]['manifest_name'] == 'test_manifest'
+
+
+def test_manifest_listing_failure(httpx_mock, capfd):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP GET request
+    httpx_mock.add_response(
+        method='GET',
+        url=f'{srv_manifest.endpoint}/manifest?project_code=test_project&manifest_name=',
+        json={'error_msg': 'Manifest not found'},
+        status_code=404,
+    )
+    try:
+        _ = srv_manifest.list_manifest('test_project')
+    except SystemExit:
+        out, _ = capfd.readouterr()
+        assert 'List Manifest Failed' in out
+
+
+def test_manifest_attach_success(httpx_mock):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP POST request
+    httpx_mock.add_response(
+        method='POST',
+        url=f'{srv_manifest.endpoint}/manifest/attach',
+        json={'result': {'id': '123', 'manifest_name': 'test_manifest'}},
+        status_code=200,
+    )
+
+    attached = srv_manifest.attach_manifest({'manifest_name': 'test_manifest'}, 'item_id', 'zone')
+    assert attached
+
+
+def test_manifest_attach_failure(httpx_mock, capfd):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP POST request
+    httpx_mock.add_response(
+        method='POST',
+        url=f'{srv_manifest.endpoint}/manifest/attach',
+        json={'error_msg': 'Attachment failed'},
+        status_code=400,
+    )
+
+    try:
+        _ = srv_manifest.attach_manifest({'manifest_name': 'test_manifest'}, 'item_id', 'zone')
+    except SystemExit:
+        out, _ = capfd.readouterr()
+        assert 'Attribute Attach Failed' in out
+
+
+def test_manifest_export_success(httpx_mock):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP GET request
+    httpx_mock.add_response(
+        method='GET',
+        url=f'{srv_manifest.endpoint}/manifest/export?project_code=test_project&name=test_manifest',
+        json={'result': {'id': '123', 'manifest_name': 'test_manifest'}},
+        status_code=200,
+    )
+
+    exported = srv_manifest.export_manifest('test_project', 'test_manifest')
+    assert exported['manifest_name'] == 'test_manifest'
+
+
+@pytest.mark.parametrize(
+    'error_code, error_msg',
+    [
+        (403, 'Project Code not found in your project'),
+        (404, 'not found in Project'),
+    ],
+)
+def test_manifest_export_failure(httpx_mock, capfd, error_code, error_msg):
+    srv_manifest = SrvFileManifests()
+    # Mock the HTTP GET request
+    httpx_mock.add_response(
+        method='GET',
+        url=f'{srv_manifest.endpoint}/manifest/export?project_code=test_project&name=test_manifest',
+        json={'error_msg': 'error'},
+        status_code=error_code,
+    )
+
+    try:
+        _ = srv_manifest.export_manifest('test_project', 'test_manifest')
+    except SystemExit:
+        out, _ = capfd.readouterr()
+        assert error_msg in out


### PR DESCRIPTION
## Summary

The old logic will attach attribute template at endpoint entire upload, which is now incompatible with portal workflow. And it will need extra step to let bff-cli validate attribute. Instead, we directly pass the attribute template with pre upload api, and let metadata to check if input is valid.

## JIRA Issues

Pilot 7388

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

simplify the logic and test cases. New test cases of manifest were added

## Versions

- Pilot Release Version: 2.15
- Compatible Version: 2.15
