### PR TITLE
patch20250424: fixup the matrix is missing patch version .0

### DIFF
--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -1,9 +1,9 @@
 {"Cli Version": "3.15.0", "Pilot Release Version": "2.14.2", "Compatible Version": "2.14.2"}
 {"Cli Version": "3.15.1", "Pilot Release Version": "2.14.2", "Compatible Version": "2.14.2"}
-{"Cli Version": "3.15.2", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
-{"Cli Version": "3.16.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
-{"Cli Version": "3.17.0", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
-{"Cli Version": "3.17.1", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
-{"Cli Version": "3.17.2", "Pilot Release Version": "2.15", "Compatible Version": "2.15"}
-{"Cli Version": "3.18.0", "Pilot Release Version": "2.16", "Compatible Version": "2.16"}
-{"Cli Version": "3.19.0", "Pilot Release Version": "2.16", "Compatible Version": "2.16"}
+{"Cli Version": "3.15.2", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
+{"Cli Version": "3.16.0", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
+{"Cli Version": "3.17.0", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
+{"Cli Version": "3.17.1", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
+{"Cli Version": "3.17.2", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
+{"Cli Version": "3.18.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
+{"Cli Version": "3.19.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}


### PR DESCRIPTION
## Summary

fixup the matrix is missing patch version .0 so that bff-cli can find the correct pilot version

## JIRA Issues

no

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

no updated

## Versions

- Pilot Release Version: 2.16.0
- Compatible Version: 2.16.0
