### PR TITLE
PILOT-7598: fixup the error handling when user try to upload into trashed project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.17.0 | 2.15.0 | 2.15.0 |
 | 3.17.1 | 2.15.0 | 2.15.0 |
 | 3.17.2 | 2.15.0 | 2.15.0 |
-| 3.18.0 | 2.16.0 | 2.16.0 |
+| 3.18.0 | 2.15.1 | 2.15.1 |
 | 3.19.0 | 2.16.0 | 2.16.0 |
 | 3.19.1 | 2.16.0 | 2.16.0 |
+| 3.19.2 | 2.16 | 2.16 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.18.0 | 2.15.1 | 2.15.1 |
 | 3.19.0 | 2.16.0 | 2.16.0 |
 | 3.19.1 | 2.16.0 | 2.16.0 |
-| 3.19.2 | 2.16 | 2.16 |
+| 3.19.2 | 2.16.0 | 2.16.0 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/app/services/file_manager/file_upload/upload_client.py
+++ b/app/services/file_manager/file_upload/upload_client.py
@@ -186,7 +186,10 @@ class UploadClient(BaseAuthClient):
             response = self._post('files/exists', json=payload)
         except HTTPStatusError as e:
             response = e.response
-            SrvErrorHandler.default_handle('Error when checking file duplication', True)
+            if response.status_code == 403:
+                SrvErrorHandler.customized_handle(ECustomizedError.PERMISSION_DENIED, self.regular_file)
+            else:
+                SrvErrorHandler.default_handle('Error when checking file duplication', True)
 
         # pop the file object if the file has been uploaded
         # return the file objects that need to be uploaded

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -8,3 +8,4 @@
 {"Cli Version": "3.18.0", "Pilot Release Version": "2.15.1", "Compatible Version": "2.15.1"}
 {"Cli Version": "3.19.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
 {"Cli Version": "3.19.1", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
+{"Cli Version": "3.19.2", "Pilot Release Version": "2.16", "Compatible Version": "2.16"}

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -5,6 +5,6 @@
 {"Cli Version": "3.17.0", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
 {"Cli Version": "3.17.1", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
 {"Cli Version": "3.17.2", "Pilot Release Version": "2.15.0", "Compatible Version": "2.15.0"}
-{"Cli Version": "3.18.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
+{"Cli Version": "3.18.0", "Pilot Release Version": "2.15.1", "Compatible Version": "2.15.1"}
 {"Cli Version": "3.19.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
 {"Cli Version": "3.19.1", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -8,4 +8,4 @@
 {"Cli Version": "3.18.0", "Pilot Release Version": "2.15.1", "Compatible Version": "2.15.1"}
 {"Cli Version": "3.19.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
 {"Cli Version": "3.19.1", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
-{"Cli Version": "3.19.2", "Pilot Release Version": "2.16", "Compatible Version": "2.16"}
+{"Cli Version": "3.19.2", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.1"
+version = "3.19.2"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/services/file_manager/file_upload/test_upload_client.py
+++ b/tests/app/services/file_manager/file_upload/test_upload_client.py
@@ -348,6 +348,7 @@ def test_check_upload_duplication_fail_with_403(httpx_mock, mocker, capfd):
 
         expect = 'Permission denied. Please verify your role in the Project has permission to perform this action.\n'
         assert out == expect
+
     else:
         raise AssertionError('SystemExit not raised')
 

--- a/tests/app/services/file_manager/file_upload/test_upload_client.py
+++ b/tests/app/services/file_manager/file_upload/test_upload_client.py
@@ -326,6 +326,32 @@ def test_check_upload_duplication_success(httpx_mock, mocker, case_insensitive):
     assert dup_list == [dup_obj.object_path.upper() if case_insensitive else dup_obj.object_path]
 
 
+def test_check_upload_duplication_fail_with_403(httpx_mock, mocker, capfd):
+    mocker.patch(
+        'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',
+        return_value=decoded_token(),
+    )
+    upload_client = UploadClient('project_code', 'parent_folder_id')
+
+    url = AppConfig.Connections.url_base + '/portal/v1/files/exists'
+    httpx_mock.add_response(
+        method='POST',
+        url=url,
+        json={'result': []},
+        status_code=403,
+    )
+
+    try:
+        upload_client.check_upload_duplication([])
+    except SystemExit:
+        out, _ = capfd.readouterr()
+
+        expect = 'Permission denied. Please verify your role in the Project has permission to perform this action.\n'
+        assert out == expect
+    else:
+        raise AssertionError('SystemExit not raised')
+
+
 def test_check_upload_duplication_fail_with_500(httpx_mock, mocker, capfd):
     mocker.patch(
         'app.services.user_authentication.token_manager.SrvTokenManager.decode_access_token',

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -204,7 +204,7 @@ def test_normalize_join():
 
 def test_get_version_compatibility_pass(httpx_mock):
     httpx_mock.add_response(
-        url=AppConfig.Connections.url_bff + '/v1/validate/cli/version?version=1.0.0',
+        url=AppConfig.Connections.url_bff + '/public/v1/validate/cli/version?version=1.0.0',
         method='GET',
         json={
             'result': {
@@ -219,7 +219,7 @@ def test_get_version_compatibility_pass(httpx_mock):
 
 def test_get_version_compatibility_fail_with_version_not_found(httpx_mock, capsys):
     httpx_mock.add_response(
-        url=AppConfig.Connections.url_bff + '/v1/validate/cli/version?version=1.0.0',
+        url=AppConfig.Connections.url_bff + '/public/v1/validate/cli/version?version=1.0.0',
         method='GET',
         json={'result': {}},
         status_code=200,
@@ -234,7 +234,7 @@ def test_get_version_compatibility_fail_with_version_incompatible(httpx_mock, ca
     min_cli_version = '1.1.0'
     min_server_version = '1.2.0'
     httpx_mock.add_response(
-        url=AppConfig.Connections.url_bff + '/v1/validate/cli/version?version=1.0.0',
+        url=AppConfig.Connections.url_bff + '/public/v1/validate/cli/version?version=1.0.0',
         method='GET',
         json={
             'result': {


### PR DESCRIPTION
## Summary

fixup the error handling when user try to upload into trashed project where old error message is Error when checking file duplication. Which is a bit confusing, now update to permission error: Permission denied. Please verify your role in the Project has permission to perform this action.


## JIRA Issues

PILOT-7598

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

add new test case for 403

## Versions

- Pilot Release Version: 2.16
- Compatible Version: 2.16
