### PR TITLE
PILOT-7687: correct the single file upload logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.19.0 | 2.16.0 | 2.16.0 |
 | 3.19.1 | 2.16.0 | 2.16.0 |
 | 3.19.2 | 2.16.0 | 2.16.0 |
+| 3.19.3 | 2.16.0 | 2.16.0 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/app/services/file_manager/file_tag.py
+++ b/app/services/file_manager/file_tag.py
@@ -16,6 +16,7 @@ from app.services.user_authentication.decorator import require_valid_token
 
 
 class SrvFileTag(metaclass=MetaService):
+
     appconfig = AppConfig()
     user: UserConfig
 

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -209,11 +209,7 @@ def simple_upload(  # noqa: C901
             upload_file_path = get_file_in_folder(input_path)
     else:
         upload_file_path = [input_path]
-
-        if create_folder_flag:
-            job_type = UploadType.AS_FOLDER
-        else:
-            job_type = UploadType.AS_FILE
+        job_type = UploadType.AS_FILE
 
     upload_client = UploadClient(
         project_code=project_code,

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -9,3 +9,4 @@
 {"Cli Version": "3.19.0", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
 {"Cli Version": "3.19.1", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
 {"Cli Version": "3.19.2", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}
+{"Cli Version": "3.19.3", "Pilot Release Version": "2.16.0", "Compatible Version": "2.16.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.2"
+version = "3.19.3"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

Now if create_folder_flag is raised, and upload target is SINGLE file, the process will be treated as AS_FILE upload.

## JIRA Issues

PILOT-7687

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

test against dev env

## Versions

- Pilot Release Version: 2.16.0
- Compatible Version: 2.16.0
