### PR TITLE
Pilot 7946: pilotcli 3.19.5 won't run on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   get-version:
     name: Get pilot cli version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       cli_version: ${{steps.get-version.outputs.cli_version}}
     steps:
@@ -39,7 +39,7 @@ jobs:
   build-and-push-docker-image:
       needs: [get-version]
       name: Build Docker images and push to repositories
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
         - name: Checkout code
           uses: actions/checkout@v3

--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   get-version:
     name: Get pilot cli version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       cli_version: ${{steps.get-version.outputs.cli_version}}
     steps:
@@ -39,7 +39,7 @@ jobs:
   build-and-push-docker-image:
       needs: [get-version]
       name: Build Docker images and push to repositories
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       steps:
         - name: Checkout code
           uses: actions/checkout@v3

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   pre-build-setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.merged == true  # Runs only if PR is merged
 
     outputs:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   pre-build-setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true  # Runs only if PR is merged
 
     outputs:
@@ -69,7 +69,7 @@ jobs:
   push-binary-linux:
     needs: [ pre-build-setup ]
     if: ${{ needs.pre-build-setup.outputs.branch == 'main' || needs.pre-build-setup.outputs.branch == 'develop'}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       upload_url: ${{steps.create_release.outputs.upload_url}}
     steps:
@@ -83,17 +83,12 @@ jobs:
         with:
           name: release-message
 
-      - name: Download Release Message Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: release-message
-
-      - name: Set up Python
+      - name: Set up Python for version extraction
         uses: actions/setup-python@v4
         with:
           python-version: 3.10.12
 
-      - name: Install Poetry
+      - name: Install Poetry for version extraction
         uses: snok/install-poetry@v1
         with:
           version: 1.8.3
@@ -101,22 +96,27 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Set up cache
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-linux-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
-        run: timeout 10s poetry run pip --version || rm -rf .venv
-
-      - name: Install dependencies
-        run: poetry install --no-interaction
-
-      - name: Build default binary
-        run: poetry run pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --paths=./.venv/lib/python3.10/site-packages ./app/pilotcli.py -n ${{ github.sha }}
+      - name: Build default binary using manylinux_2_31
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/io quay.io/pypa/manylinux_2_31_x86_64 bash -c "
+            cd /io
+            mkdir -p ./app/bundled_app/linux ./app/build/linux
+            
+            # Install Poetry
+            curl -sSL https://install.python-poetry.org | python3 -
+            export PATH=\$PATH:/root/.local/bin
+            
+            # Configure and install dependencies
+            cd /io
+            poetry config virtualenvs.create false
+            poetry install --no-interaction
+            
+            # Install PyInstaller
+            pip install pyinstaller
+            
+            # Build binary
+            pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux ./app/pilotcli.py -n ${{ github.sha }}
+          "
 
       - name: Rename default output file
         run: mv "./app/bundled_app/linux/${{ github.sha }}" "./app/bundled_app/linux/pilotcli_linux"
@@ -124,8 +124,17 @@ jobs:
       - name: Enable cloud mode
         run: touch ./app/ENABLE_CLOUD_MODE
 
-      - name: Build cloud binary
-        run: poetry run pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --paths=./.venv/lib/python3.9/site-packages --add-binary=$(pwd)/app/ENABLE_CLOUD_MODE:. ./app/pilotcli.py -n ${{ github.sha }}
+      - name: Build cloud binary using manylinux_2_31
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/io quay.io/pypa/manylinux_2_31_x86_64 bash -c "
+            cd /io
+            
+            # Poetry should already be installed from previous step
+            export PATH=\$PATH:/root/.local/bin
+            
+            # Build cloud binary
+            pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --add-binary=/io/app/ENABLE_CLOUD_MODE:. ./app/pilotcli.py -n ${{ github.sha }}
+          "
 
       - name: Rename cloud output file
         run: mv "./app/bundled_app/linux/${{ github.sha }}" "./app/bundled_app/linux/pilotcli_cloud"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -101,19 +101,19 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/io quay.io/pypa/manylinux_2_31_x86_64 bash -c "
             cd /io
             mkdir -p ./app/bundled_app/linux ./app/build/linux
-            
+
             # Install Poetry
             curl -sSL https://install.python-poetry.org | python3 -
             export PATH=\$PATH:/root/.local/bin
-            
+
             # Configure and install dependencies
             cd /io
             poetry config virtualenvs.create false
             poetry install --no-interaction
-            
+
             # Install PyInstaller
             pip install pyinstaller
-            
+
             # Build binary
             pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux ./app/pilotcli.py -n ${{ github.sha }}
           "
@@ -128,10 +128,10 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/io quay.io/pypa/manylinux_2_31_x86_64 bash -c "
             cd /io
-            
+
             # Poetry should already be installed from previous step
             export PATH=\$PATH:/root/.local/bin
-            
+
             # Build cloud binary
             pyinstaller -F --distpath ./app/bundled_app/linux --specpath ./app/build/linux --workpath ./app/build/linux --add-binary=/io/app/ENABLE_CLOUD_MODE:. ./app/pilotcli.py -n ${{ github.sha }}
           "

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-compatible-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-compatible-versions:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.19.2 | 2.15.2 | 2.15.2 |
 | 3.19.3 | 2.15.2 | 2.15.2 |
 | 3.19.4 | 2.15.2 | 2.15.2 |
+| 3.19.5 | 2.15.2 | 2.15.2 |
+| 3.19.6 | 2.15.2 | 2.15.2 |
+| 3.19.7 | 2.15.2 | 2.15.2 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -12,3 +12,4 @@
 {"Cli Version": "3.19.3", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.4", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.5", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
+{"Cli Version": "3.19.6", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -13,3 +13,4 @@
 {"Cli Version": "3.19.4", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.5", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.6", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
+{"Cli Version": "3.19.7", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.5"
+version = "3.19.6"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.6"
+version = "3.19.7"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 


### PR DESCRIPTION
## Summary

- Updated remaining workflows.

## JIRA Issues

pilotcli 3.19.5 won't run on Ubuntu 20.04

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)

## Versions

- Pilot Release Version: 2.15.2
- Compatible Version: 2.15.2
