### PR TITLE
PILOT-7924: fixup the download link is not compatible with platform

### DIFF
--- a/.github/workflows/update_compatible_version.yml
+++ b/.github/workflows/update_compatible_version.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-compatible-versions:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.19.2 | 2.15.2 | 2.15.2 |
 | 3.19.3 | 2.15.2 | 2.15.2 |
 | 3.19.4 | 2.15.2 | 2.15.2 |
+| 3.19.5 | 2.15.2 | 2.15.2 |
+| 3.19.6 | 2.15.2 | 2.15.2 |
+| 3.19.7 | 2.15.2 | 2.15.2 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Command line tool that allows the user to execute data operations on the platfor
 | 3.19.5 | 2.15.2 | 2.15.2 |
 | 3.19.6 | 2.15.2 | 2.15.2 |
 | 3.19.7 | 2.15.2 | 2.15.2 |
+| 3.20.0 | 2.15.2 | 2.15.2 |
 <!-- COMPATIBLE_VERSIONS_END -->
 
 ## Build Instructions

--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -251,7 +251,7 @@ def get_latest_cli_version() -> Tuple[Version, str]:
 
         # extract the download URL by platform
         platform_key = 'macos' if platform.system() == 'Darwin' else platform.system().lower()
-        download_details = result.get(platform_key, None)
+        download_details = result.get(platform_key, {})
 
         latest_version = download_details.get('version', '0.0.0')
         download_url = download_details.get('download_url', '')

--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -250,8 +250,8 @@ def get_latest_cli_version() -> Tuple[Version, str]:
         result = response.json().get('result', {})
 
         # extract the download URL by platform
-        plaform = 'macos' if platform.system() == 'Darwin' else platform.system().lower()
-        download_details = result.get(plaform, None)
+        platform_key = 'macos' if platform.system() == 'Darwin' else platform.system().lower()
+        download_details = result.get(platform_key, None)
 
         latest_version = download_details.get('version', '0.0.0')
         download_url = download_details.get('download_url', '')

--- a/app/utils/aggregated.py
+++ b/app/utils/aggregated.py
@@ -3,6 +3,7 @@
 # Contact Indoc Systems for any questions regarding the use of this source code.
 
 import os
+import platform
 import re
 import shutil
 import time
@@ -247,8 +248,13 @@ def get_latest_cli_version() -> Tuple[Version, str]:
         headers = {'Authorization': 'Bearer'}
         response = httpx_client._get('v1/download/cli/presigned', headers=headers)
         result = response.json().get('result', {})
-        latest_version = result.get('linux', {}).get('version', '0.0.0')
-        download_url = result.get('linux', {}).get('download_url', '')
+
+        # extract the download URL by platform
+        plaform = 'macos' if platform.system() == 'Darwin' else platform.system().lower()
+        download_details = result.get(plaform, None)
+
+        latest_version = download_details.get('version', '0.0.0')
+        download_url = download_details.get('download_url', '')
 
         return Version(latest_version), download_url
     except (SystemExit, Exception):

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -14,3 +14,4 @@
 {"Cli Version": "3.19.5", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.6", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.7", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
+{"Cli Version": "3.20.0", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}

--- a/docs/compatible_version.ndjson
+++ b/docs/compatible_version.ndjson
@@ -13,3 +13,4 @@
 {"Cli Version": "3.19.4", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.5", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
 {"Cli Version": "3.19.6", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}
+{"Cli Version": "3.19.7", "Pilot Release Version": "2.15.2", "Compatible Version": "2.15.2"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.6"
+version = "3.19.7"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "app"
-version = "3.19.7"
+version = "3.20.0"
 description = "This service is designed to support pilot platform"
 authors = ["Indoc Systems"]
 

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -7,6 +7,7 @@ import pytest
 from app.configs.app_config import AppConfig
 from app.models.item import ItemType
 from app.utils.aggregated import check_item_duplication
+from app.utils.aggregated import get_latest_cli_version
 from app.utils.aggregated import get_version_compatibility
 from app.utils.aggregated import identify_target_folder
 from app.utils.aggregated import normalize_input_paths
@@ -251,3 +252,34 @@ def test_get_version_compatibility_fail_with_version_incompatible(httpx_mock, ca
         f'CLI version is incompatible with server version. Please update the CLI to version {min_cli_version}'
         + f' or later, and minimum server version is {min_server_version}.'
     ) in out.rstrip()
+
+
+@pytest.mark.parametrize('platform_name', ['Linux', 'Windows', 'Darwin'])
+def test_get_download_link_by_platform(mocker, platform_name, httpx_mock):
+    mocker.patch('platform.system', return_value=platform_name)
+    expected_result = {
+        'linux': {
+            'version': '1.0.0',
+            'download_url': 'https://example.com/download/linux',
+        },
+        'windows': {
+            'version': '1.0.1',
+            'download_url': 'https://example.com/download/windows',
+        },
+        'macos': {
+            'version': '1.1.0',
+            'download_url': 'https://example.com/download/macos',
+        },
+    }
+    httpx_mock.add_response(
+        url=AppConfig.Connections.url_fileops_greenroom + '/v1/download/cli/presigned',
+        method='GET',
+        json={'result': expected_result},
+        status_code=200,
+    )
+
+    version, url = get_latest_cli_version()
+    if platform_name.lower() == 'darwin':
+        platform_name = 'macos'
+    assert str(version) == expected_result[platform_name.lower()]['version']
+    assert url == expected_result[platform_name.lower()]['download_url']

--- a/tests/app/utils/test_aggregated.py
+++ b/tests/app/utils/test_aggregated.py
@@ -256,7 +256,7 @@ def test_get_version_compatibility_fail_with_version_incompatible(httpx_mock, ca
 
 @pytest.mark.parametrize('platform_name', ['Linux', 'Windows', 'Darwin'])
 def test_get_download_link_by_platform(mocker, platform_name, httpx_mock):
-    mocker.patch('platform.system', return_value=platform_name)
+    mocker.patch('app.utils.aggregated.platform.system', return_value=platform_name)
     expected_result = {
         'linux': {
             'version': '1.0.0',


### PR DESCRIPTION
## Summary

The old notification message always report to linux download link in windows and macos platform. The PR will display download link based on platform.

## JIRA Issues

PILOT-7924

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

Add new test cases for different platform.

## Versions

- Pilot Release Version: 2.15.2
- Compatible Version: 2.15.2
