### PR TITLE
PILOT-7930: fixup upload as zip feature

### DIFF
--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -194,19 +194,24 @@ def simple_upload(  # noqa: C901
     # if the input request zip folder then process the path as single file
     # otherwise read throught the folder to get path underneath
     if os.path.isdir(input_path):
-        job_type = UploadType.AS_FILE if compress_zip else UploadType.AS_FOLDER
-        if job_type == UploadType.AS_FILE:
-            upload_file_path = [input_path.rstrip('/').lstrip() + '.zip']
-            compress_folder_to_zip(input_path)
+        if compress_zip:
+            input_path = compress_folder_to_zip(input_path)
+            upload_file_path = [input_path]
+            job_type = UploadType.AS_FILE
+            # since now this is a file upload, we need to strip the folder name
+            current_folder_node = os.path.dirname(current_folder_node)
+        else:
+            job_type = UploadType.AS_FOLDER
+            upload_file_path = get_file_in_folder(input_path)
+
         # currently not support tag and attribute for a folder upload
-        elif tags or attribute:
+        if tags or attribute:
             SrvErrorHandler.customized_handle(ECustomizedError.UNSUPPORT_TAG_MANIFEST, True)
         # currently not support n-to-n relationship in lineage, meaning
         # can ONLY specify one source id for a folder upload
         elif len(source_id) > 1 and job_type == UploadType.AS_FOLDER:
             SrvErrorHandler.customized_handle(ECustomizedError.UNSUPPORT_SOURCE_MANIFEST, True)
-        else:
-            upload_file_path = get_file_in_folder(input_path)
+
     else:
         upload_file_path = [input_path]
         job_type = UploadType.AS_FILE
@@ -255,7 +260,6 @@ def simple_upload(  # noqa: C901
         upload_client.output_manifest(
             pre_upload_infos, non_duplicate_file_objects[len(pre_upload_infos) + 1 :], output_path
         )
-
     # now loop over each file under the folder and start
     # the chunk upload
     pool = ThreadPool(num_of_thread)

--- a/app/services/file_manager/file_upload/file_upload.py
+++ b/app/services/file_manager/file_upload/file_upload.py
@@ -195,8 +195,8 @@ def simple_upload(  # noqa: C901
     # otherwise read throught the folder to get path underneath
     if os.path.isdir(input_path):
         if compress_zip:
-            input_path = compress_folder_to_zip(input_path)
-            upload_file_path = [input_path]
+            zip_file_path = compress_folder_to_zip(input_path)
+            upload_file_path = [zip_file_path]
             job_type = UploadType.AS_FILE
             # since now this is a file upload, we need to strip the folder name
             current_folder_node = os.path.dirname(current_folder_node)

--- a/tests/app/services/file_manager/file_upload/test_file_upload.py
+++ b/tests/app/services/file_manager/file_upload/test_file_upload.py
@@ -349,6 +349,33 @@ def test_folder_merge_skip_with_all_duplication(mocker, mock_upload_client, capf
         raise AssertionError('SystemExit not raised')
 
 
+def test_upload_folder_as_zip(mocker, mock_upload_client):
+    test_folder = 'test'
+    upload_event = {
+        'file': test_folder,
+        'project_code': 'test_project',
+        'zone': 'greenroom',
+        'create_folder_flag': False,
+        'compress_zip': True,
+    }
+
+    mocker.patch('os.path.isdir', return_value=True)
+    mocker.patch('app.services.file_manager.file_upload.models.FileObject.generate_meta', return_value=(1, 1))
+    compress_mock = mocker.patch(
+        'app.services.file_manager.file_upload.file_upload.compress_folder_to_zip', return_value='test.zip'
+    )
+
+    non_dup_list = [FileObject('object/path', 'local_path', 'resumable_id', 'job_id', 'item_id')]
+    mocker.patch(
+        'app.services.file_manager.file_upload.file_upload.UploadClient.check_upload_duplication',
+        return_value=(non_dup_list, []),
+    )
+    item_ids = simple_upload(upload_event)
+    assert len(item_ids) == 1
+    assert item_ids[0] == non_dup_list[0].item_id
+    assert compress_mock.call_count == 1
+
+
 def test_resume_upload(mocker):
     mocker.patch('app.services.file_manager.file_upload.models.FileObject.generate_meta', return_value=(1, 1))
     test_obj = FileObject('object/path', 'local_path', 'resumable_id', 'job_id', 'item_id')


### PR DESCRIPTION
## Summary

after updating on upload type in this PR: https://github.com/PilotDataPlatform/cli/pull/235. It introduced another bug where the upload path is not correct when upload a zip. This PR update the logic for upload as zip. But entire logic need to be refactored later on.

## JIRA Issues

PILOT-7930

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [x] Yes
- [ ] No

## Test Directions

update test cases and test against dev

## Versions

- Pilot Release Version: 2.15.2
- Compatible Version: 2.15.2
